### PR TITLE
feat: add axe-core automated accessibility testing in CI/CD

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -1,0 +1,38 @@
+name: Accessibility (axe-core)
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  a11y:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run axe-core accessibility tests
+        run: npm run test:a11y -- --project=chromium
+        env:
+          BASE_URL: ${{ secrets.BASE_URL || 'http://localhost:3000' }}
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: a11y-report
+          path: playwright-report/
+          retention-days: 30

--- a/README.md
+++ b/README.md
@@ -180,6 +180,19 @@ stellar-scanner time-travel upgrade --contract-id CONTRACT_ID --wasm-file new.wa
 
 For detailed documentation, see [TIME_TRAVEL_DEBUGGER.md](TIME_TRAVEL_DEBUGGER.md).
 
+## ♿ Accessibility Testing
+
+Automated WCAG 2.1 AA accessibility checks run on every push and PR via the
+`Accessibility (axe-core)` GitHub Actions workflow, powered by
+[`@axe-core/playwright`](https://github.com/dequelabs/axe-core-npm).
+
+```bash
+npm run test:a11y
+```
+
+See [docs/ACCESSIBILITY_TESTING.md](docs/ACCESSIBILITY_TESTING.md) for details
+on the suite, adding routes, tuning rules, and the CI workflow.
+
 ## 🛠️ Technology Stack
 
 ### Frontend

--- a/docs/ACCESSIBILITY_TESTING.md
+++ b/docs/ACCESSIBILITY_TESTING.md
@@ -1,0 +1,101 @@
+# Accessibility Testing
+
+Automated accessibility testing for the Soroban Security Scanner frontend using
+[axe-core](https://github.com/dequelabs/axe-core) integrated with Playwright.
+
+## Overview
+
+Tests run on every push and pull request against `main` and `develop` via the
+`Accessibility (axe-core)` GitHub Actions workflow
+(`.github/workflows/accessibility.yml`). Locally they run through Playwright.
+
+The suite checks the application against the following rule sets:
+
+- WCAG 2.0 Level A
+- WCAG 2.0 Level AA
+- WCAG 2.1 Level A
+- WCAG 2.1 Level AA
+
+This complements the existing Lighthouse accessibility budget configured in
+`lighthouserc.js`: Lighthouse measures the accessibility category score on
+production-like builds; axe-core provides rule-level violations against
+specific routes and components, which is more actionable for fixes.
+
+## Running Locally
+
+Install dependencies (the first time):
+
+```bash
+npm install
+npx playwright install --with-deps chromium
+```
+
+Run the full accessibility suite:
+
+```bash
+npm run test:a11y
+```
+
+Run against a specific URL:
+
+```bash
+BASE_URL=https://staging.example.com npm run test:a11y
+```
+
+Open the HTML report after a run:
+
+```bash
+npx playwright show-report
+```
+
+## Test Structure
+
+The suite lives in `tests/e2e/accessibility.spec.js`:
+
+- **Per-route scans** — full-page axe analysis for each public route (home,
+  results) using the WCAG A/AA tag sets.
+- **Form scope** — narrows axe to the `form` element to ensure inputs expose
+  accessible names, labels, and roles.
+- **Navigation scope** — narrows axe to the `nav` landmark.
+- **Color contrast** — focused run of the `color-contrast` rule on the home
+  page.
+
+When a test fails, the violations are printed to the console with their `id`,
+`impact`, `help` text, and a `helpUrl` linking to Deque's remediation guide.
+
+## Adding a New Page to the Suite
+
+Append the route to the `ROUTES` array in
+`tests/e2e/accessibility.spec.js`:
+
+```js
+const ROUTES = [
+  { name: 'home page', path: '/' },
+  { name: 'scan results page', path: '/results' },
+  { name: 'new page',         path: '/new-page' },
+];
+```
+
+## Tuning Rules
+
+Disable a rule (with justification) using `disableRules`:
+
+```js
+const results = await new AxeBuilder({ page })
+  .withTags(WCAG_TAGS)
+  .disableRules(['region']) // false positive: app intentionally lacks a region landmark on this page
+  .analyze();
+```
+
+Prefer fixing violations over disabling rules. Document any disabled rule with
+an inline comment explaining the rationale.
+
+## CI/CD
+
+The workflow installs only Chromium (a single browser is sufficient for axe
+checks since axe analyzes the rendered DOM, not browser-specific behavior),
+runs `npm run test:a11y`, and uploads the Playwright report as the
+`a11y-report` artifact for 30 days.
+
+A failing axe assertion fails the workflow, blocking merges that introduce
+WCAG violations.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "scan": "node src/index.js",
     "test": "jest",
     "test:e2e": "playwright test",
+    "test:a11y": "playwright test tests/e2e/accessibility.spec.js",
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
     "format": "prettier --write \"src/**/*.js\"",
@@ -37,6 +38,8 @@
     "jest": "^29.7.0",
     "eslint": "^8.57.0",
     "prettier": "^3.2.5",
-    "@playwright/test": "^1.44.0"
+    "@playwright/test": "^1.44.0",
+    "@axe-core/playwright": "^4.9.1",
+    "axe-core": "^4.9.1"
   }
 }

--- a/tests/e2e/accessibility.spec.js
+++ b/tests/e2e/accessibility.spec.js
@@ -1,0 +1,80 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+const AxeBuilder = require('@axe-core/playwright').default;
+
+const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'];
+
+const ROUTES = [
+  { name: 'home page', path: '/' },
+  { name: 'scan results page', path: '/results' },
+];
+
+test.describe('Accessibility (axe-core) - WCAG 2.1 AA', () => {
+  for (const route of ROUTES) {
+    test(`${route.name} has no detectable a11y violations`, async ({ page }) => {
+      await page.goto(route.path);
+      await page.waitForLoadState('domcontentloaded');
+
+      const results = await new AxeBuilder({ page })
+        .withTags(WCAG_TAGS)
+        .analyze();
+
+      if (results.violations.length > 0) {
+        console.log(
+          `\nA11y violations on ${route.path}:\n` +
+            JSON.stringify(
+              results.violations.map((v) => ({
+                id: v.id,
+                impact: v.impact,
+                help: v.help,
+                helpUrl: v.helpUrl,
+                nodes: v.nodes.length,
+              })),
+              null,
+              2
+            )
+        );
+      }
+
+      expect(results.violations).toEqual([]);
+    });
+  }
+
+  test('scan form controls expose accessible names', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+
+    const results = await new AxeBuilder({ page })
+      .withTags(WCAG_TAGS)
+      .include('form')
+      .analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test('navigation landmark has no a11y violations', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+
+    const nav = page.getByRole('navigation');
+    if (await nav.count()) {
+      const results = await new AxeBuilder({ page })
+        .withTags(WCAG_TAGS)
+        .include('nav')
+        .analyze();
+
+      expect(results.violations).toEqual([]);
+    }
+  });
+
+  test('color contrast meets WCAG AA on home page', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+
+    const results = await new AxeBuilder({ page })
+      .withRules(['color-contrast'])
+      .analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #93.

Adds automated WCAG 2.0/2.1 A and AA accessibility testing to CI/CD by
integrating [`@axe-core/playwright`](https://github.com/dequelabs/axe-core-npm)
with the existing Playwright setup, so violations block merges instead of
slipping into `develop`/`main`.

## Changes

- **`tests/e2e/accessibility.spec.js`** — new Playwright suite that runs axe
  against the home (`/`) and results (`/results`) routes, narrows to the
  `form` and `nav` landmarks, and runs a focused `color-contrast` pass on the
  home page. Violations are pretty-printed (id, impact, help, helpUrl, node
  count) so failures are actionable.
- **`.github/workflows/accessibility.yml`** — new GitHub Actions workflow
  triggered on push/PR to `main` and `develop`. Installs Chromium only
  (sufficient for axe DOM analysis), runs `npm run test:a11y`, uploads the
  Playwright report as the `a11y-report` artifact for 30 days. A failing
  rule fails the workflow.
- **`package.json`** — adds the `test:a11y` script and the
  `@axe-core/playwright` + `axe-core` devDependencies.
- **`docs/ACCESSIBILITY_TESTING.md`** — usage, structure, how to add routes,
  how/when to disable rules, and how this complements the existing Lighthouse
  accessibility budget in `lighthouserc.js`.
- **`README.md`** — adds an Accessibility Testing section pointing to the doc
  and the `npm run test:a11y` command.

## How it relates to existing tooling

The repo already enforces a Lighthouse accessibility category score of `0.9`
in `lighthouserc.js`. Lighthouse gives a single score on production-like
builds; axe-core surfaces rule-level violations against specific routes and
components, which is more actionable for fixing issues. The two are
complementary, not redundant.

## Test plan

- [ ] `npm ci` installs the new devDependencies cleanly
- [ ] `npx playwright install --with-deps chromium` succeeds
- [ ] `npm run test:a11y` runs the new suite locally (against a running
      frontend at `BASE_URL`, default `http://localhost:3000`)
- [ ] `Accessibility (axe-core)` workflow runs and passes on this PR
- [ ] Workflow uploads the `a11y-report` artifact on completion
- [ ] Existing `E2E & Visual Regression Tests` and `Lighthouse CI` workflows
      still pass (no shared config touched)