### PR TITLE
Improve frontend SEO metadata and SSR shell

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,11 +1,55 @@
 import type { Metadata, Viewport } from 'next';
+import type { ReactNode } from 'react';
 import { headers } from 'next/headers';
 import './globals.css';
 import { PageErrorBoundary } from '@/components/ui/ErrorBoundary';
+import {
+  getSiteUrl,
+  siteDescription,
+  siteKeywords,
+  siteName,
+  softwareApplicationJsonLd,
+} from '@/lib/seo';
+
+const siteUrl = getSiteUrl();
 
 export const metadata: Metadata = {
-  title: 'Soroban Security Scanner',
-  description: 'Smart contract security analysis for the Soroban ecosystem',
+  metadataBase: new URL(siteUrl),
+  title: {
+    default: siteName,
+    template: `%s | ${siteName}`,
+  },
+  description: siteDescription,
+  applicationName: siteName,
+  keywords: siteKeywords,
+  authors: [{ name: 'Soroban Security Scanner contributors' }],
+  creator: 'Soroban Security Scanner contributors',
+  category: 'Security',
+  alternates: {
+    canonical: '/',
+  },
+  openGraph: {
+    type: 'website',
+    url: '/',
+    title: siteName,
+    description: siteDescription,
+    siteName,
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: siteName,
+    description: siteDescription,
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      'max-image-preview': 'large',
+      'max-snippet': -1,
+    },
+  },
 };
 
 export const viewport: Viewport = {
@@ -15,7 +59,7 @@ export const viewport: Viewport = {
   viewportFit: 'cover', // support iPhone notch / safe areas
 };
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default function RootLayout({ children }: { children: ReactNode }) {
   // Get the CSP nonce from middleware
   const headersList = headers();
   const nonce = headersList.get('x-nonce') || '';
@@ -23,6 +67,16 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body>
+        <script
+          type="application/ld+json"
+          nonce={nonce}
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              ...softwareApplicationJsonLd,
+              url: siteUrl,
+            }).replace(/</g, '\\u003c'),
+          }}
+        />
         <PageErrorBoundary>{children}</PageErrorBoundary>
       </body>
     </html>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Suspense, useState, useEffect } from 'react';
+import { Suspense, useState } from 'react';
 import dynamic from 'next/dynamic';
 import { SectionErrorBoundary } from '@/components/ui/ErrorBoundary';
 import { 
@@ -132,17 +132,12 @@ export default function App() {
   const [selectedSubmission, setSelectedSubmission] = useState<BountySubmissionType | null>(null);
   const [disputes, setDisputes] = useState<DisputeData[]>([]);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
-  const [isClient, setIsClient] = useState(false);
 
   const { 
     setActiveTour, 
     helpPanelTopic, 
     setHelpPanelTopic 
   } = useHelpStore();
-
-  useEffect(() => {
-    setIsClient(true);
-  }, []);
 
   const handleBountySelect = (bounty: Bounty) => {
     setSelectedBounty(bounty);
@@ -264,8 +259,6 @@ export default function App() {
         return null;
     }
   };
-
-  if (!isClient) return null;
 
   return (
     <div className="min-h-screen bg-gray-50">

--- a/frontend/app/robots.ts
+++ b/frontend/app/robots.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from 'next';
+import { getSiteUrl } from '@/lib/seo';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+      },
+    ],
+    sitemap: `${getSiteUrl()}/sitemap.xml`,
+  };
+}

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from 'next';
+import { getSiteUrl } from '@/lib/seo';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: getSiteUrl(),
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+  ];
+}

--- a/frontend/lib/seo.ts
+++ b/frontend/lib/seo.ts
@@ -1,0 +1,41 @@
+export const siteName = 'Soroban Security Scanner';
+
+export const siteDescription =
+  'Automated security analysis for Soroban smart contracts, with vulnerability scanning, reporting, and researcher workflows.';
+
+export const siteKeywords = [
+  'Soroban security scanner',
+  'Stellar smart contract audit',
+  'Soroban vulnerability scanner',
+  'smart contract security',
+  'Stellar security tooling',
+  'Web3 security analysis',
+];
+
+export function getSiteUrl() {
+  const explicitUrl = process.env.NEXT_PUBLIC_SITE_URL;
+  const vercelUrl = process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : undefined;
+
+  return (explicitUrl || vercelUrl || 'http://localhost:3000').replace(/\/$/, '');
+}
+
+export const softwareApplicationJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'SoftwareApplication',
+  name: siteName,
+  applicationCategory: 'SecurityApplication',
+  operatingSystem: 'Web',
+  description: siteDescription,
+  keywords: siteKeywords.join(', '),
+  featureList: [
+    'Soroban smart contract vulnerability scanning',
+    'Security report generation',
+    'Bounty and researcher workflow management',
+    'Transaction and contract analysis dashboards',
+  ],
+  offers: {
+    '@type': 'Offer',
+    price: '0',
+    priceCurrency: 'USD',
+  },
+};

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -163,8 +163,16 @@ export function middleware(request: NextRequest) {
   // Get security headers
   const securityHeaders = getSecurityHeaders(nonce, isProduction);
   
+  // Expose the nonce to server components that render inline scripts.
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set('x-nonce', nonce);
+
   // Create response
-  const response = NextResponse.next();
+  const response = NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  });
   
   // Apply all security headers
   Object.entries(securityHeaders).forEach(([key, value]) => {


### PR DESCRIPTION
## Summary
- adds shared frontend SEO metadata for titles, descriptions, Open Graph, Twitter, canonical, and crawler rules
- adds JSON-LD SoftwareApplication structured data with the existing CSP nonce
- adds robots and sitemap routes and lets the main page render its shell on the server instead of returning a blank initial page

## Checks
- npm run build
- git diff --check

Closes #76