### PR TITLE
feat(auth): multi-factor authentication for admin access (#328)

### DIFF
--- a/src/admin_mfa/anomaly.rs
+++ b/src/admin_mfa/anomaly.rs
@@ -1,0 +1,243 @@
+//! Session anomaly detection for admin logins.
+//!
+//! Scores each login attempt against the account's recent history across four
+//! signals — IP address, device fingerprint, geographic location and
+//! time-of-day — producing a risk level that drives an automatic step-up MFA
+//! challenge for suspicious attempts.
+
+use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
+
+/// How many recent logins to retain per account for baselining.
+const HISTORY_LIMIT: usize = 20;
+
+/// A single login signal set.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LoginContext {
+    /// Source IP address (string form, v4 or v6).
+    pub ip: String,
+    /// Stable device/browser fingerprint.
+    pub device_fingerprint: String,
+    /// Coarse location code (e.g. ISO country, or "US-CA").
+    pub location: String,
+    /// Hour of day in UTC (0–23) of the attempt.
+    pub hour_utc: u8,
+}
+
+/// Risk classification for a login attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum RiskLevel {
+    /// Matches the established baseline.
+    Low,
+    /// Some novelty; warrants a step-up challenge.
+    Medium,
+    /// Strong novelty across multiple signals; always challenge.
+    High,
+}
+
+/// The result of scoring a login.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AnomalyAssessment {
+    /// Numeric score in `[0.0, 1.0]`.
+    pub score: f64,
+    /// Bucketed risk level.
+    pub level: RiskLevel,
+    /// Human-readable reasons contributing to the score.
+    pub reasons: Vec<String>,
+}
+
+impl AnomalyAssessment {
+    /// Whether this assessment should trigger an automatic MFA challenge.
+    pub fn requires_challenge(&self) -> bool {
+        self.level >= RiskLevel::Medium
+    }
+}
+
+/// Tunable thresholds for the detector.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct AnomalyConfig {
+    /// Score at/above which risk is Medium.
+    pub medium_threshold: f64,
+    /// Score at/above which risk is High.
+    pub high_threshold: f64,
+    /// Hours of deviation from the usual login time treated as unusual.
+    pub unusual_hour_delta: u8,
+}
+
+impl Default for AnomalyConfig {
+    fn default() -> Self {
+        Self {
+            medium_threshold: 0.3,
+            high_threshold: 0.6,
+            unusual_hour_delta: 6,
+        }
+    }
+}
+
+/// Detects anomalies against a rolling per-account history.
+#[derive(Debug, Clone)]
+pub struct AnomalyDetector {
+    config: AnomalyConfig,
+    history: VecDeque<LoginContext>,
+}
+
+impl AnomalyDetector {
+    /// Creates a detector with the given configuration and no history.
+    pub fn new(config: AnomalyConfig) -> Self {
+        Self {
+            config,
+            history: VecDeque::new(),
+        }
+    }
+
+    /// Number of historical logins retained.
+    pub fn history_len(&self) -> usize {
+        self.history.len()
+    }
+
+    /// Scores `ctx` against history **without** recording it.
+    pub fn assess(&self, ctx: &LoginContext) -> AnomalyAssessment {
+        // With no baseline yet, the first login is treated as elevated so the
+        // account establishes MFA from the outset.
+        if self.history.is_empty() {
+            return AnomalyAssessment {
+                score: self.config.medium_threshold,
+                level: RiskLevel::Medium,
+                reasons: vec!["no login history to baseline against".to_string()],
+            };
+        }
+
+        let mut score: f64 = 0.0;
+        let mut reasons = Vec::new();
+
+        if !self.history.iter().any(|h| h.ip == ctx.ip) {
+            score += 0.30;
+            reasons.push("new IP address".to_string());
+        }
+        if !self.history.iter().any(|h| h.device_fingerprint == ctx.device_fingerprint) {
+            score += 0.30;
+            reasons.push("unrecognized device".to_string());
+        }
+        if !self.history.iter().any(|h| h.location == ctx.location) {
+            score += 0.30;
+            reasons.push("new location".to_string());
+        }
+        if self.is_unusual_hour(ctx.hour_utc) {
+            score += 0.15;
+            reasons.push("unusual login hour".to_string());
+        }
+
+        let score = score.min(1.0);
+        let level = if score >= self.config.high_threshold {
+            RiskLevel::High
+        } else if score >= self.config.medium_threshold {
+            RiskLevel::Medium
+        } else {
+            RiskLevel::Low
+        };
+
+        AnomalyAssessment { score, level, reasons }
+    }
+
+    /// Records a (presumably accepted) login into the rolling history.
+    pub fn record(&mut self, ctx: LoginContext) {
+        self.history.push_back(ctx);
+        while self.history.len() > HISTORY_LIMIT {
+            self.history.pop_front();
+        }
+    }
+
+    /// Convenience: assess then record in one call.
+    pub fn assess_and_record(&mut self, ctx: LoginContext) -> AnomalyAssessment {
+        let assessment = self.assess(&ctx);
+        self.record(ctx);
+        assessment
+    }
+
+    fn is_unusual_hour(&self, hour: u8) -> bool {
+        // Compare against the circular-mean-ish set of known hours: unusual if
+        // it is more than `unusual_hour_delta` from every historical hour.
+        let delta = self.config.unusual_hour_delta;
+        self.history.iter().all(|h| circular_hour_distance(h.hour_utc, hour) > delta)
+    }
+}
+
+/// Distance between two hours on a 24-hour clock (0–12).
+fn circular_hour_distance(a: u8, b: u8) -> u8 {
+    let diff = (a as i16 - b as i16).unsigned_abs() as u8;
+    diff.min(24 - diff)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx(ip: &str, device: &str, location: &str, hour: u8) -> LoginContext {
+        LoginContext {
+            ip: ip.to_string(),
+            device_fingerprint: device.to_string(),
+            location: location.to_string(),
+            hour_utc: hour,
+        }
+    }
+
+    fn baseline() -> AnomalyDetector {
+        let mut d = AnomalyDetector::new(AnomalyConfig::default());
+        d.record(ctx("203.0.113.1", "device-A", "US-CA", 9));
+        d.record(ctx("203.0.113.1", "device-A", "US-CA", 10));
+        d
+    }
+
+    #[test]
+    fn first_login_is_elevated() {
+        let d = AnomalyDetector::new(AnomalyConfig::default());
+        let a = d.assess(&ctx("203.0.113.1", "device-A", "US-CA", 9));
+        assert!(a.requires_challenge());
+    }
+
+    #[test]
+    fn familiar_login_is_low_risk() {
+        let d = baseline();
+        let a = d.assess(&ctx("203.0.113.1", "device-A", "US-CA", 9));
+        assert_eq!(a.level, RiskLevel::Low);
+        assert!(!a.requires_challenge());
+    }
+
+    #[test]
+    fn new_ip_only_is_medium() {
+        let d = baseline();
+        let a = d.assess(&ctx("198.51.100.9", "device-A", "US-CA", 9));
+        assert_eq!(a.level, RiskLevel::Medium);
+        assert!(a.reasons.iter().any(|r| r.contains("IP")));
+    }
+
+    #[test]
+    fn new_ip_device_and_location_is_high() {
+        let d = baseline();
+        let a = d.assess(&ctx("8.8.8.8", "device-Z", "RU-MOW", 3));
+        assert_eq!(a.level, RiskLevel::High);
+        assert!(a.requires_challenge());
+    }
+
+    #[test]
+    fn unusual_hour_contributes() {
+        let d = baseline(); // usual hours 9–10
+        let a = d.assess(&ctx("203.0.113.1", "device-A", "US-CA", 2));
+        assert!(a.reasons.iter().any(|r| r.contains("hour")));
+    }
+
+    #[test]
+    fn history_is_capped() {
+        let mut d = AnomalyDetector::new(AnomalyConfig::default());
+        for i in 0..(HISTORY_LIMIT + 5) {
+            d.record(ctx("203.0.113.1", "device-A", "US-CA", (i % 24) as u8));
+        }
+        assert_eq!(d.history_len(), HISTORY_LIMIT);
+    }
+
+    #[test]
+    fn circular_distance_wraps_midnight() {
+        assert_eq!(circular_hour_distance(23, 1), 2);
+        assert_eq!(circular_hour_distance(0, 12), 12);
+    }
+}

--- a/src/admin_mfa/backup_codes.rs
+++ b/src/admin_mfa/backup_codes.rs
@@ -1,0 +1,160 @@
+//! Single-use recovery backup codes.
+//!
+//! Codes are shown to the user once at generation and only their SHA-256
+//! hashes are retained, so a database leak does not expose usable codes. Each
+//! code can be redeemed exactly once.
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// Default number of backup codes issued per generation.
+pub const DEFAULT_COUNT: usize = 10;
+/// Number of random bytes behind each code (→ 16 hex chars).
+const CODE_BYTES: usize = 8;
+
+/// Plaintext codes returned to the user once, alongside the storable set.
+#[derive(Debug, Clone)]
+pub struct GeneratedBackupCodes {
+    /// Human-readable codes to display exactly once.
+    pub plaintext: Vec<String>,
+    /// Hashed, storable representation.
+    pub store: BackupCodeSet,
+}
+
+/// A storable set of hashed backup codes.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BackupCodeSet {
+    /// SHA-256 hex digests of unused codes.
+    hashes: Vec<String>,
+    /// Count of codes consumed so far.
+    used: usize,
+}
+
+impl BackupCodeSet {
+    /// Generates `count` fresh codes using the supplied RNG, returning both the
+    /// plaintext (to show once) and the hashed set (to store).
+    pub fn generate(count: usize, rng: &mut impl rand::RngCore) -> GeneratedBackupCodes {
+        let mut plaintext = Vec::with_capacity(count);
+        let mut hashes = Vec::with_capacity(count);
+        for _ in 0..count {
+            let mut bytes = [0u8; CODE_BYTES];
+            rng.fill_bytes(&mut bytes);
+            let code = format_code(&bytes);
+            hashes.push(hash(&code));
+            plaintext.push(code);
+        }
+        GeneratedBackupCodes {
+            plaintext,
+            store: BackupCodeSet { hashes, used: 0 },
+        }
+    }
+
+    /// Number of unused codes remaining.
+    pub fn remaining(&self) -> usize {
+        self.hashes.len()
+    }
+
+    /// Number of codes consumed.
+    pub fn used(&self) -> usize {
+        self.used
+    }
+
+    /// Redeems a code, consuming it on success. Returns `true` if the code was
+    /// valid and previously unused.
+    pub fn redeem(&mut self, code: &str) -> bool {
+        let target = hash(code.trim());
+        if let Some(pos) = self
+            .hashes
+            .iter()
+            .position(|h| constant_time_eq(h.as_bytes(), target.as_bytes()))
+        {
+            self.hashes.remove(pos);
+            self.used += 1;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+fn format_code(bytes: &[u8]) -> String {
+    // Group as XXXX-XXXX-XXXX-XXXX for readability.
+    let hexed: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
+    hexed
+        .as_bytes()
+        .chunks(4)
+        .map(|c| std::str::from_utf8(c).unwrap())
+        .collect::<Vec<_>>()
+        .join("-")
+}
+
+fn hash(code: &str) -> String {
+    // Normalise away the readability dashes/case before hashing.
+    let normalized: String = code.chars().filter(|c| *c != '-').collect::<String>().to_lowercase();
+    let mut hasher = Sha256::new();
+    hasher.update(normalized.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generates_requested_count() {
+        let mut rng = rand::rngs::OsRng;
+        let gen = BackupCodeSet::generate(DEFAULT_COUNT, &mut rng);
+        assert_eq!(gen.plaintext.len(), DEFAULT_COUNT);
+        assert_eq!(gen.store.remaining(), DEFAULT_COUNT);
+    }
+
+    #[test]
+    fn code_redeems_once() {
+        let mut rng = rand::rngs::OsRng;
+        let gen = BackupCodeSet::generate(3, &mut rng);
+        let mut set = gen.store;
+        let code = &gen.plaintext[0];
+        assert!(set.redeem(code));
+        assert_eq!(set.remaining(), 2);
+        assert_eq!(set.used(), 1);
+        // Second attempt with the same code fails.
+        assert!(!set.redeem(code));
+    }
+
+    #[test]
+    fn redeem_ignores_dashes_and_case() {
+        let mut rng = rand::rngs::OsRng;
+        let gen = BackupCodeSet::generate(1, &mut rng);
+        let mut set = gen.store;
+        let stripped = gen.plaintext[0].replace('-', "").to_uppercase();
+        assert!(set.redeem(&stripped));
+    }
+
+    #[test]
+    fn unknown_code_is_rejected() {
+        let mut rng = rand::rngs::OsRng;
+        let mut set = BackupCodeSet::generate(2, &mut rng).store;
+        assert!(!set.redeem("0000-0000-0000-0000"));
+        assert_eq!(set.remaining(), 2);
+    }
+
+    #[test]
+    fn only_hashes_are_stored() {
+        let mut rng = rand::rngs::OsRng;
+        let gen = BackupCodeSet::generate(1, &mut rng);
+        // The plaintext must not appear in the serialized store.
+        let json = serde_json::to_string(&gen.store).unwrap();
+        assert!(!json.contains(&gen.plaintext[0].replace('-', "")));
+    }
+}

--- a/src/admin_mfa/base32.rs
+++ b/src/admin_mfa/base32.rs
@@ -1,0 +1,84 @@
+//! Minimal RFC 4648 base32 codec (no padding) for TOTP shared secrets.
+//!
+//! Authenticator apps (Google Authenticator, Authy, 1Password, …) expect the
+//! shared secret in `otpauth://` URIs to be base32-encoded, so we need a small
+//! dependency-free codec rather than the base64 already in the tree.
+
+const ALPHABET: &[u8; 32] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+
+/// Encodes bytes as uppercase base32 without padding.
+pub fn encode(data: &[u8]) -> String {
+    let mut out = String::new();
+    let mut buffer: u32 = 0;
+    let mut bits: u32 = 0;
+    for &byte in data {
+        buffer = (buffer << 8) | byte as u32;
+        bits += 8;
+        while bits >= 5 {
+            bits -= 5;
+            let idx = ((buffer >> bits) & 0x1f) as usize;
+            out.push(ALPHABET[idx] as char);
+        }
+    }
+    if bits > 0 {
+        let idx = ((buffer << (5 - bits)) & 0x1f) as usize;
+        out.push(ALPHABET[idx] as char);
+    }
+    out
+}
+
+/// Decodes a base32 string, ignoring case, padding (`=`) and spaces.
+///
+/// Returns `None` if a non-alphabet character is encountered.
+pub fn decode(input: &str) -> Option<Vec<u8>> {
+    let mut buffer: u32 = 0;
+    let mut bits: u32 = 0;
+    let mut out = Vec::new();
+    for c in input.chars() {
+        if c == '=' || c == ' ' {
+            continue;
+        }
+        let val = match c.to_ascii_uppercase() {
+            'A'..='Z' => c.to_ascii_uppercase() as u32 - 'A' as u32,
+            '2'..='7' => c as u32 - '2' as u32 + 26,
+            _ => return None,
+        };
+        buffer = (buffer << 5) | val;
+        bits += 5;
+        if bits >= 8 {
+            bits -= 8;
+            out.push((buffer >> bits) as u8);
+        }
+    }
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips() {
+        for case in [&b""[..], b"f", b"fo", b"foo", b"foob", b"fooba", b"foobar"] {
+            let encoded = encode(case);
+            assert_eq!(decode(&encoded).unwrap(), case);
+        }
+    }
+
+    #[test]
+    fn known_vector() {
+        // RFC 4648: "foobar" -> "MZXW6YTBOI"
+        assert_eq!(encode(b"foobar"), "MZXW6YTBOI");
+        assert_eq!(decode("MZXW6YTBOI").unwrap(), b"foobar");
+    }
+
+    #[test]
+    fn tolerates_lowercase_spaces_padding() {
+        assert_eq!(decode("mzxw 6ytb oi==").unwrap(), b"foobar");
+    }
+
+    #[test]
+    fn rejects_invalid_chars() {
+        assert!(decode("0189!").is_none());
+    }
+}

--- a/src/admin_mfa/emergency.rs
+++ b/src/admin_mfa/emergency.rs
@@ -1,0 +1,242 @@
+//! Emergency MFA-bypass procedure with multi-admin approval.
+//!
+//! When an admin is locked out (lost device, etc.), a *break-glass* bypass can
+//! be granted — but only with quorum approval from other admins. A request
+//! collects distinct approvals; once the quorum is met it yields a one-time,
+//! time-limited bypass grant. The locked-out account cannot approve its own
+//! request, and every action is recorded for audit.
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Configuration for the emergency procedure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EmergencyConfig {
+    /// Number of distinct admin approvals required (quorum).
+    pub required_approvals: usize,
+    /// How long a granted bypass remains valid, in seconds.
+    pub grant_validity_secs: i64,
+    /// How long a request may collect approvals before expiring, in seconds.
+    pub request_ttl_secs: i64,
+}
+
+impl Default for EmergencyConfig {
+    fn default() -> Self {
+        Self {
+            required_approvals: 2,
+            grant_validity_secs: 15 * 60,
+            request_ttl_secs: 60 * 60,
+        }
+    }
+}
+
+/// Status of an emergency bypass request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum BypassStatus {
+    /// Still collecting approvals.
+    Pending,
+    /// Quorum met; a grant is active until the contained timestamp.
+    Granted {
+        /// Unix timestamp at which the grant expires.
+        expires_at: i64,
+    },
+    /// Request expired before quorum / grant consumed or revoked.
+    Closed,
+}
+
+/// Errors from the emergency workflow.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EmergencyError {
+    /// The target account may not approve its own bypass.
+    SelfApproval,
+    /// This admin already approved.
+    DuplicateApproval,
+    /// The request is no longer pending.
+    NotPending,
+    /// The request has passed its TTL.
+    RequestExpired,
+}
+
+/// A break-glass bypass request for a locked-out admin.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BypassRequest {
+    /// Request id.
+    pub id: Uuid,
+    /// The locked-out account the bypass is for.
+    pub target: Uuid,
+    /// The admin who initiated the request.
+    pub initiator: Uuid,
+    /// When the request was opened (unix secs).
+    pub created_at: i64,
+    /// Distinct approving admins.
+    approvals: Vec<Uuid>,
+    /// Current status.
+    pub status: BypassStatus,
+    cfg: EmergencyConfig,
+}
+
+impl BypassRequest {
+    /// Opens a request. The initiator counts as the first approver (an admin
+    /// vouching for the break-glass), but the target can never be the
+    /// initiator.
+    pub fn open(
+        target: Uuid,
+        initiator: Uuid,
+        now: i64,
+        cfg: EmergencyConfig,
+    ) -> Result<Self, EmergencyError> {
+        if target == initiator {
+            return Err(EmergencyError::SelfApproval);
+        }
+        let mut req = Self {
+            id: Uuid::new_v4(),
+            target,
+            initiator,
+            created_at: now,
+            approvals: vec![initiator],
+            status: BypassStatus::Pending,
+            cfg,
+        };
+        req.maybe_grant(now);
+        Ok(req)
+    }
+
+    /// Number of distinct approvals collected.
+    pub fn approval_count(&self) -> usize {
+        self.approvals.len()
+    }
+
+    /// Adds an approval from `admin`. Grants the bypass once quorum is reached.
+    pub fn approve(&mut self, admin: Uuid, now: i64) -> Result<&BypassStatus, EmergencyError> {
+        if self.status != BypassStatus::Pending {
+            return Err(EmergencyError::NotPending);
+        }
+        if now - self.created_at > self.cfg.request_ttl_secs {
+            self.status = BypassStatus::Closed;
+            return Err(EmergencyError::RequestExpired);
+        }
+        if admin == self.target {
+            return Err(EmergencyError::SelfApproval);
+        }
+        if self.approvals.contains(&admin) {
+            return Err(EmergencyError::DuplicateApproval);
+        }
+        self.approvals.push(admin);
+        self.maybe_grant(now);
+        Ok(&self.status)
+    }
+
+    /// Whether a valid bypass grant is currently active at `now`.
+    pub fn is_bypass_active(&self, now: i64) -> bool {
+        matches!(self.status, BypassStatus::Granted { expires_at } if now <= expires_at)
+    }
+
+    /// Consumes the grant (one-time use), closing the request.
+    pub fn consume(&mut self, now: i64) -> bool {
+        if self.is_bypass_active(now) {
+            self.status = BypassStatus::Closed;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Cancels/revokes the request.
+    pub fn revoke(&mut self) {
+        self.status = BypassStatus::Closed;
+    }
+
+    fn maybe_grant(&mut self, now: i64) {
+        if self.approvals.len() >= self.cfg.required_approvals {
+            self.status = BypassStatus::Granted {
+                expires_at: now + self.cfg.grant_validity_secs,
+            };
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg() -> EmergencyConfig {
+        EmergencyConfig::default() // requires 2 approvals
+    }
+
+    #[test]
+    fn quorum_grants_bypass() {
+        let target = Uuid::new_v4();
+        let admin1 = Uuid::new_v4();
+        let admin2 = Uuid::new_v4();
+        let mut req = BypassRequest::open(target, admin1, 1000, cfg()).unwrap();
+        assert_eq!(req.status, BypassStatus::Pending); // 1 of 2
+        req.approve(admin2, 1000).unwrap();
+        assert!(req.is_bypass_active(1000));
+    }
+
+    #[test]
+    fn target_cannot_initiate_or_approve() {
+        let target = Uuid::new_v4();
+        assert_eq!(
+            BypassRequest::open(target, target, 1000, cfg()).unwrap_err(),
+            EmergencyError::SelfApproval
+        );
+        let mut req = BypassRequest::open(target, Uuid::new_v4(), 1000, cfg()).unwrap();
+        assert_eq!(req.approve(target, 1000).unwrap_err(), EmergencyError::SelfApproval);
+    }
+
+    #[test]
+    fn duplicate_approval_is_rejected() {
+        // Quorum 3 so the request stays Pending after one extra approval,
+        // leaving room to exercise the duplicate-approval guard.
+        let custom = EmergencyConfig {
+            required_approvals: 3,
+            ..cfg()
+        };
+        let mut req = BypassRequest::open(Uuid::new_v4(), Uuid::new_v4(), 1000, custom).unwrap();
+        let admin2 = Uuid::new_v4();
+        req.approve(admin2, 1000).unwrap();
+        assert_eq!(req.status, BypassStatus::Pending); // 2 of 3
+        // admin2 again
+        assert_eq!(req.approve(admin2, 1000).unwrap_err(), EmergencyError::DuplicateApproval);
+    }
+
+    #[test]
+    fn grant_expires() {
+        let mut req = BypassRequest::open(Uuid::new_v4(), Uuid::new_v4(), 1000, cfg()).unwrap();
+        req.approve(Uuid::new_v4(), 1000).unwrap();
+        let expiry = 1000 + cfg().grant_validity_secs;
+        assert!(req.is_bypass_active(expiry));
+        assert!(!req.is_bypass_active(expiry + 1));
+    }
+
+    #[test]
+    fn grant_is_one_time() {
+        let mut req = BypassRequest::open(Uuid::new_v4(), Uuid::new_v4(), 1000, cfg()).unwrap();
+        req.approve(Uuid::new_v4(), 1000).unwrap();
+        assert!(req.consume(1000));
+        assert!(!req.is_bypass_active(1000)); // closed after consume
+        assert!(!req.consume(1000));
+    }
+
+    #[test]
+    fn request_ttl_expires_pending() {
+        let mut req = BypassRequest::open(Uuid::new_v4(), Uuid::new_v4(), 1000, cfg()).unwrap();
+        let late = 1000 + cfg().request_ttl_secs + 1;
+        assert_eq!(req.approve(Uuid::new_v4(), late).unwrap_err(), EmergencyError::RequestExpired);
+        assert_eq!(req.status, BypassStatus::Closed);
+    }
+
+    #[test]
+    fn three_approval_quorum() {
+        let custom = EmergencyConfig {
+            required_approvals: 3,
+            ..cfg()
+        };
+        let mut req = BypassRequest::open(Uuid::new_v4(), Uuid::new_v4(), 1000, custom).unwrap();
+        req.approve(Uuid::new_v4(), 1000).unwrap();
+        assert_eq!(req.status, BypassStatus::Pending); // 2 of 3
+        req.approve(Uuid::new_v4(), 1000).unwrap();
+        assert!(req.is_bypass_active(1000)); // 3 of 3
+    }
+}

--- a/src/admin_mfa/manager.rs
+++ b/src/admin_mfa/manager.rs
@@ -1,0 +1,358 @@
+//! Top-level MFA orchestration.
+//!
+//! [`MfaManager`] holds per-account factor state and ties the pieces together
+//! into the login decision flow: it applies the enrollment policy, scores the
+//! attempt for anomalies, and verifies individual factors (TOTP with replay
+//! protection, SMS, backup codes, WebAuthn).
+
+use crate::admin_mfa::anomaly::{AnomalyAssessment, AnomalyConfig, AnomalyDetector, LoginContext};
+use crate::admin_mfa::backup_codes::BackupCodeSet;
+use crate::admin_mfa::policy::{MfaEnrollment, MfaMethod, MfaPolicy, PolicyDecision, Role};
+use crate::admin_mfa::totp::TotpConfig;
+use crate::admin_mfa::webauthn::{
+    AssertionResponse, AssertionVerifier, RegisteredCredential, WebAuthnError, WebAuthnRegistry,
+};
+use std::collections::HashMap;
+use uuid::Uuid;
+
+/// Provisioning data returned when setting up TOTP.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TotpSetup {
+    /// Base32 secret for manual entry.
+    pub secret_base32: String,
+    /// `otpauth://` URI for QR-code enrollment.
+    pub uri: String,
+}
+
+/// The decision produced at the start of a login.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LoginDecision {
+    /// Whether enrollment policy is satisfied.
+    pub policy: PolicyDecision,
+    /// Anomaly scoring of the attempt.
+    pub anomaly: AnomalyAssessment,
+    /// Whether a second factor must be presented before access is granted.
+    pub mfa_required: bool,
+}
+
+impl LoginDecision {
+    /// Whether the login may proceed to issue a session without further steps.
+    pub fn is_clear(&self) -> bool {
+        self.policy == PolicyDecision::Allow && !self.mfa_required
+    }
+}
+
+/// Per-account MFA state.
+struct AccountMfa {
+    role: Role,
+    enrollment: MfaEnrollment,
+    totp: Option<TotpConfig>,
+    last_totp_counter: Option<u64>,
+    sms_phone: Option<String>,
+    backup: BackupCodeSet,
+    anomaly: AnomalyDetector,
+}
+
+impl AccountMfa {
+    fn new(role: Role) -> Self {
+        Self {
+            role,
+            enrollment: MfaEnrollment::none(),
+            totp: None,
+            last_totp_counter: None,
+            sms_phone: None,
+            backup: BackupCodeSet::default(),
+            anomaly: AnomalyDetector::new(AnomalyConfig::default()),
+        }
+    }
+}
+
+/// Orchestrates MFA across all accounts.
+pub struct MfaManager {
+    policy: MfaPolicy,
+    accounts: HashMap<Uuid, AccountMfa>,
+    webauthn: WebAuthnRegistry,
+}
+
+impl MfaManager {
+    /// Creates a manager with the given policy.
+    pub fn new(policy: MfaPolicy) -> Self {
+        Self {
+            policy,
+            accounts: HashMap::new(),
+            webauthn: WebAuthnRegistry::new(),
+        }
+    }
+
+    /// Registers an account with a role (idempotent: re-registering resets role).
+    pub fn add_account(&mut self, user: Uuid, role: Role) {
+        self.accounts.entry(user).or_insert_with(|| AccountMfa::new(role)).role = role;
+    }
+
+    /// Returns the account's enrollment snapshot, if registered.
+    pub fn enrollment(&self, user: Uuid) -> Option<&MfaEnrollment> {
+        self.accounts.get(&user).map(|a| &a.enrollment)
+    }
+
+    /// Read-only access to the WebAuthn registry.
+    pub fn webauthn(&self) -> &WebAuthnRegistry {
+        &self.webauthn
+    }
+
+    /// Mutable access to the WebAuthn registry (challenge issuance, etc.).
+    pub fn webauthn_mut(&mut self) -> &mut WebAuthnRegistry {
+        &mut self.webauthn
+    }
+
+    // --- Enrollment -------------------------------------------------------
+
+    /// Begins TOTP setup, returning provisioning data. The factor is not
+    /// marked enrolled until [`confirm_totp`](Self::confirm_totp) succeeds.
+    pub fn setup_totp(
+        &mut self,
+        user: Uuid,
+        issuer: &str,
+        account_label: &str,
+        rng: &mut impl rand::RngCore,
+    ) -> Option<TotpSetup> {
+        let acct = self.accounts.get_mut(&user)?;
+        let cfg = TotpConfig::generate(rng);
+        let setup = TotpSetup {
+            secret_base32: cfg.secret_base32(),
+            uri: cfg.provisioning_uri(issuer, account_label),
+        };
+        acct.totp = Some(cfg);
+        acct.last_totp_counter = None;
+        Some(setup)
+    }
+
+    /// Confirms TOTP enrollment by verifying a freshly generated code.
+    pub fn confirm_totp(&mut self, user: Uuid, code: &str, now_secs: u64) -> bool {
+        let Some(acct) = self.accounts.get_mut(&user) else {
+            return false;
+        };
+        let Some(cfg) = &acct.totp else { return false };
+        if let Some(counter) = cfg.verify_at(code, now_secs) {
+            acct.last_totp_counter = Some(counter);
+            acct.enrollment.enroll(MfaMethod::Totp);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Enrolls an SMS phone number as a fallback factor.
+    pub fn setup_sms(&mut self, user: Uuid, phone: impl Into<String>) -> bool {
+        let Some(acct) = self.accounts.get_mut(&user) else {
+            return false;
+        };
+        acct.sms_phone = Some(phone.into());
+        acct.enrollment.enroll(MfaMethod::Sms);
+        true
+    }
+
+    /// The enrolled SMS phone, if any.
+    pub fn sms_phone(&self, user: Uuid) -> Option<&str> {
+        self.accounts.get(&user).and_then(|a| a.sms_phone.as_deref())
+    }
+
+    /// Registers a WebAuthn credential and marks the factor enrolled.
+    pub fn register_webauthn(&mut self, user: Uuid, credential: RegisteredCredential) -> bool {
+        let Some(acct) = self.accounts.get_mut(&user) else {
+            return false;
+        };
+        self.webauthn.register(user, credential);
+        acct.enrollment.enroll(MfaMethod::WebAuthn);
+        true
+    }
+
+    /// Generates and stores backup codes, returning the plaintext to show once.
+    pub fn generate_backup_codes(
+        &mut self,
+        user: Uuid,
+        count: usize,
+        rng: &mut impl rand::RngCore,
+    ) -> Option<Vec<String>> {
+        let acct = self.accounts.get_mut(&user)?;
+        let generated = BackupCodeSet::generate(count, rng);
+        acct.backup = generated.store;
+        acct.enrollment.enroll(MfaMethod::BackupCode);
+        Some(generated.plaintext)
+    }
+
+    // --- Login flow -------------------------------------------------------
+
+    /// Scores a login attempt and decides what is required, recording the
+    /// context into the anomaly baseline.
+    pub fn begin_login(&mut self, user: Uuid, ctx: LoginContext, now_secs: i64) -> Option<LoginDecision> {
+        let acct = self.accounts.get_mut(&user)?;
+        let policy = self.policy.evaluate(acct.role, &acct.enrollment);
+        let anomaly = acct.anomaly.assess_and_record(ctx);
+        let mfa_required =
+            self.policy.mfa_enforced(acct.role, &acct.enrollment) || anomaly.requires_challenge();
+        let _ = now_secs; // reserved for future time-based scoring
+        Some(LoginDecision {
+            policy,
+            anomaly,
+            mfa_required,
+        })
+    }
+
+    // --- Factor verification ---------------------------------------------
+
+    /// Verifies a TOTP code at login, enforcing replay protection (a counter
+    /// may not be reused).
+    pub fn verify_totp(&mut self, user: Uuid, code: &str, now_secs: u64) -> bool {
+        let Some(acct) = self.accounts.get_mut(&user) else {
+            return false;
+        };
+        if !acct.enrollment.has(MfaMethod::Totp) {
+            return false;
+        }
+        let Some(cfg) = &acct.totp else { return false };
+        match cfg.verify_at(code, now_secs) {
+            Some(counter) => {
+                if acct.last_totp_counter.is_some_and(|last| counter <= last) {
+                    // Replay of an already-used (or older) step.
+                    false
+                } else {
+                    acct.last_totp_counter = Some(counter);
+                    true
+                }
+            }
+            None => false,
+        }
+    }
+
+    /// Redeems a single-use backup code.
+    pub fn redeem_backup_code(&mut self, user: Uuid, code: &str) -> bool {
+        let Some(acct) = self.accounts.get_mut(&user) else {
+            return false;
+        };
+        acct.backup.redeem(code)
+    }
+
+    /// Remaining unused backup codes.
+    pub fn backup_codes_remaining(&self, user: Uuid) -> usize {
+        self.accounts.get(&user).map(|a| a.backup.remaining()).unwrap_or(0)
+    }
+
+    /// Verifies a WebAuthn assertion for a user.
+    pub fn verify_webauthn(
+        &mut self,
+        user: Uuid,
+        challenge_id: Uuid,
+        response: &AssertionResponse,
+        verifier: &dyn AssertionVerifier,
+        now_secs: i64,
+    ) -> Result<(), WebAuthnError> {
+        self.webauthn
+            .verify_assertion(user, challenge_id, response, verifier, now_secs)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn login_ctx() -> LoginContext {
+        LoginContext {
+            ip: "203.0.113.1".to_string(),
+            device_fingerprint: "device-A".to_string(),
+            location: "US-CA".to_string(),
+            hour_utc: 9,
+        }
+    }
+
+    #[test]
+    fn admin_must_enroll_before_clearing_policy() {
+        let mut mgr = MfaManager::new(MfaPolicy::default());
+        let admin = Uuid::new_v4();
+        mgr.add_account(admin, Role::Admin);
+        let decision = mgr.begin_login(admin, login_ctx(), 1000).unwrap();
+        assert_eq!(decision.policy, PolicyDecision::AdminMfaRequired);
+        assert!(decision.mfa_required);
+    }
+
+    #[test]
+    fn totp_enrollment_and_login() {
+        let mut mgr = MfaManager::new(MfaPolicy::default());
+        let admin = Uuid::new_v4();
+        mgr.add_account(admin, Role::Admin);
+
+        let mut rng = rand::rngs::OsRng;
+        let setup = mgr.setup_totp(admin, "Soroban", "admin@example.com", &mut rng).unwrap();
+        assert!(setup.uri.starts_with("otpauth://"));
+
+        // Confirm with a current code derived from the stored secret.
+        let now = 1_700_000_100u64;
+        let cfg = TotpConfig::from_secret(
+            crate::admin_mfa::base32::decode(&setup.secret_base32).unwrap(),
+        );
+        let code = cfg.code_at(now);
+        assert!(mgr.confirm_totp(admin, &code, now));
+        assert!(mgr.enrollment(admin).unwrap().has(MfaMethod::Totp));
+
+        // Policy is now satisfied.
+        let decision = mgr.begin_login(admin, login_ctx(), now as i64).unwrap();
+        assert_eq!(decision.policy, PolicyDecision::Allow);
+
+        // Login-time verification works once...
+        let later = now + 60;
+        let code2 = cfg.code_at(later);
+        assert!(mgr.verify_totp(admin, &code2, later));
+        // ...and the same code is rejected on replay.
+        assert!(!mgr.verify_totp(admin, &code2, later));
+    }
+
+    #[test]
+    fn backup_codes_are_single_use() {
+        let mut mgr = MfaManager::new(MfaPolicy::default());
+        let user = Uuid::new_v4();
+        mgr.add_account(user, Role::User);
+        let mut rng = rand::rngs::OsRng;
+        let codes = mgr.generate_backup_codes(user, 5, &mut rng).unwrap();
+        assert_eq!(mgr.backup_codes_remaining(user), 5);
+        assert!(mgr.redeem_backup_code(user, &codes[0]));
+        assert!(!mgr.redeem_backup_code(user, &codes[0]));
+        assert_eq!(mgr.backup_codes_remaining(user), 4);
+    }
+
+    #[test]
+    fn anomalous_login_forces_mfa_even_for_user_without_enrollment() {
+        let mut mgr = MfaManager::new(MfaPolicy::default());
+        let user = Uuid::new_v4();
+        mgr.add_account(user, Role::User);
+        // Establish a baseline.
+        mgr.begin_login(user, login_ctx(), 1000);
+        // Now a wildly different context.
+        let suspicious = LoginContext {
+            ip: "8.8.8.8".to_string(),
+            device_fingerprint: "device-Z".to_string(),
+            location: "RU-MOW".to_string(),
+            hour_utc: 3,
+        };
+        let decision = mgr.begin_login(user, suspicious, 2000).unwrap();
+        assert!(decision.anomaly.requires_challenge());
+        assert!(decision.mfa_required);
+    }
+
+    #[test]
+    fn sms_enrollment_records_phone() {
+        let mut mgr = MfaManager::new(MfaPolicy::default());
+        let user = Uuid::new_v4();
+        mgr.add_account(user, Role::User);
+        assert!(mgr.setup_sms(user, "+15551234567"));
+        assert_eq!(mgr.sms_phone(user), Some("+15551234567"));
+        assert!(mgr.enrollment(user).unwrap().has(MfaMethod::Sms));
+    }
+
+    #[test]
+    fn unknown_account_operations_fail_gracefully() {
+        let mut mgr = MfaManager::new(MfaPolicy::default());
+        let ghost = Uuid::new_v4();
+        assert!(mgr.begin_login(ghost, login_ctx(), 1000).is_none());
+        assert!(!mgr.verify_totp(ghost, "000000", 0));
+        assert!(!mgr.setup_sms(ghost, "+1"));
+    }
+}

--- a/src/admin_mfa/mod.rs
+++ b/src/admin_mfa/mod.rs
@@ -1,0 +1,70 @@
+//! Multi-factor authentication for administrative access (issue #328).
+//!
+//! A self-contained MFA subsystem layered on top of the existing JWT auth. It
+//! adds TOTP, FIDO2/WebAuthn and SMS factors, single-use backup codes,
+//! enrollment policy (mandatory for admins), session anomaly detection with
+//! automatic step-up challenges, sensitive-operation re-authentication, and a
+//! multi-admin emergency bypass procedure.
+//!
+//! # Acceptance-criteria mapping
+//!
+//! | Requirement | Where |
+//! |-------------|-------|
+//! | TOTP MFA (RFC 6238) | [`totp::TotpConfig`] |
+//! | Hardware keys (FIDO2/WebAuthn) | [`webauthn::WebAuthnRegistry`] |
+//! | SMS fallback | [`sms::SmsChallenge`] |
+//! | MFA enforced for admins, optional for users | [`policy::MfaPolicy`] |
+//! | Setup & recovery with backup codes | [`backup_codes::BackupCodeSet`] |
+//! | Session anomaly detection (IP/device/location/time) | [`anomaly::AnomalyDetector`] |
+//! | Automatic MFA challenge for suspicious logins | [`manager::MfaManager::begin_login`] |
+//! | Forced re-auth for sensitive operations | [`session::AdminSession`] |
+//! | Emergency bypass with multi-admin approval | [`emergency::BypassRequest`] |
+//! | Comprehensive security testing | per-module `#[cfg(test)]` + [`tests`] |
+//!
+//! # Example: admin TOTP enrollment + login
+//!
+//! ```
+//! use soroban_security_scanner::admin_mfa::*;
+//! use uuid::Uuid;
+//!
+//! let mut mgr = MfaManager::new(MfaPolicy::default());
+//! let admin = Uuid::new_v4();
+//! mgr.add_account(admin, Role::Admin);
+//!
+//! // Admins cannot clear policy until a strong factor is enrolled.
+//! let ctx = LoginContext {
+//!     ip: "203.0.113.1".into(),
+//!     device_fingerprint: "yubi-laptop".into(),
+//!     location: "US-CA".into(),
+//!     hour_utc: 9,
+//! };
+//! let decision = mgr.begin_login(admin, ctx, 1_700_000_000).unwrap();
+//! assert_eq!(decision.policy, PolicyDecision::AdminMfaRequired);
+//! ```
+
+pub mod anomaly;
+pub mod backup_codes;
+pub mod base32;
+pub mod emergency;
+pub mod manager;
+pub mod policy;
+pub mod session;
+pub mod sms;
+pub mod totp;
+pub mod webauthn;
+
+#[cfg(test)]
+mod tests;
+
+pub use anomaly::{AnomalyAssessment, AnomalyConfig, AnomalyDetector, LoginContext, RiskLevel};
+pub use backup_codes::{BackupCodeSet, GeneratedBackupCodes};
+pub use emergency::{BypassRequest, BypassStatus, EmergencyConfig, EmergencyError};
+pub use manager::{LoginDecision, MfaManager, TotpSetup};
+pub use policy::{MfaEnrollment, MfaMethod, MfaPolicy, PolicyDecision, Role};
+pub use session::{AccessDenied, AdminSession, SessionConfig, Sensitivity};
+pub use sms::{SmsChallenge, SmsSender, SmsVerifyResult};
+pub use totp::TotpConfig;
+pub use webauthn::{
+    AcceptingVerifier, AssertionResponse, AssertionVerifier, RegisteredCredential, WebAuthnChallenge,
+    WebAuthnError, WebAuthnRegistry,
+};

--- a/src/admin_mfa/policy.rs
+++ b/src/admin_mfa/policy.rs
@@ -1,0 +1,208 @@
+//! MFA enrollment state and enforcement policy.
+//!
+//! Tracks which factors each account has enrolled and decides, per the org
+//! policy, whether a given account is allowed to authenticate. Admins must
+//! have at least one strong factor; MFA is optional (but supported) for
+//! regular users.
+
+use serde::{Deserialize, Serialize};
+
+/// Account role for policy decisions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Role {
+    /// Regular platform user.
+    User,
+    /// Administrator (elevated privileges).
+    Admin,
+}
+
+/// A second-factor method.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum MfaMethod {
+    /// Authenticator-app TOTP (RFC 6238).
+    Totp,
+    /// FIDO2/WebAuthn hardware key.
+    WebAuthn,
+    /// SMS one-time code (fallback).
+    Sms,
+    /// Single-use recovery backup code.
+    BackupCode,
+}
+
+impl MfaMethod {
+    /// Whether this method is considered a *strong* factor. SMS and backup
+    /// codes are fallbacks and do not by themselves satisfy admin policy.
+    pub fn is_strong(&self) -> bool {
+        matches!(self, MfaMethod::Totp | MfaMethod::WebAuthn)
+    }
+}
+
+/// Per-account enrollment record.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MfaEnrollment {
+    totp: bool,
+    webauthn: bool,
+    sms: bool,
+    backup_codes: bool,
+}
+
+impl MfaEnrollment {
+    /// An empty enrollment (nothing set up).
+    pub fn none() -> Self {
+        Self::default()
+    }
+
+    /// Marks a method as enrolled.
+    pub fn enroll(&mut self, method: MfaMethod) {
+        self.set(method, true);
+    }
+
+    /// Marks a method as removed.
+    pub fn remove(&mut self, method: MfaMethod) {
+        self.set(method, false);
+    }
+
+    fn set(&mut self, method: MfaMethod, value: bool) {
+        match method {
+            MfaMethod::Totp => self.totp = value,
+            MfaMethod::WebAuthn => self.webauthn = value,
+            MfaMethod::Sms => self.sms = value,
+            MfaMethod::BackupCode => self.backup_codes = value,
+        }
+    }
+
+    /// Whether a method is enrolled.
+    pub fn has(&self, method: MfaMethod) -> bool {
+        match method {
+            MfaMethod::Totp => self.totp,
+            MfaMethod::WebAuthn => self.webauthn,
+            MfaMethod::Sms => self.sms,
+            MfaMethod::BackupCode => self.backup_codes,
+        }
+    }
+
+    /// Whether any second factor at all is enrolled.
+    pub fn any(&self) -> bool {
+        self.totp || self.webauthn || self.sms || self.backup_codes
+    }
+
+    /// Whether at least one *strong* factor is enrolled.
+    pub fn has_strong(&self) -> bool {
+        self.totp || self.webauthn
+    }
+}
+
+/// Organization MFA policy.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct MfaPolicy {
+    /// Admins must enroll a strong factor (cannot authenticate otherwise).
+    pub require_admin_mfa: bool,
+    /// Regular users must enroll some factor.
+    pub require_user_mfa: bool,
+}
+
+impl Default for MfaPolicy {
+    fn default() -> Self {
+        Self {
+            require_admin_mfa: true,
+            require_user_mfa: false,
+        }
+    }
+}
+
+/// Why a login is blocked by policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PolicyDecision {
+    /// Authentication may proceed (MFA may still be challenged separately).
+    Allow,
+    /// Admin lacks a required strong factor — must enroll before access.
+    AdminMfaRequired,
+    /// User lacks a required factor — must enroll before access.
+    UserMfaRequired,
+}
+
+impl MfaPolicy {
+    /// Decides whether an account with `enrollment` and `role` satisfies policy.
+    pub fn evaluate(&self, role: Role, enrollment: &MfaEnrollment) -> PolicyDecision {
+        match role {
+            Role::Admin if self.require_admin_mfa && !enrollment.has_strong() => {
+                PolicyDecision::AdminMfaRequired
+            }
+            Role::User if self.require_user_mfa && !enrollment.any() => {
+                PolicyDecision::UserMfaRequired
+            }
+            _ => PolicyDecision::Allow,
+        }
+    }
+
+    /// Whether MFA must be *enforced* (a factor verified) for this account.
+    pub fn mfa_enforced(&self, role: Role, enrollment: &MfaEnrollment) -> bool {
+        match role {
+            Role::Admin => true,
+            Role::User => enrollment.any(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn admin_without_strong_factor_is_blocked() {
+        let policy = MfaPolicy::default();
+        let mut e = MfaEnrollment::none();
+        assert_eq!(policy.evaluate(Role::Admin, &e), PolicyDecision::AdminMfaRequired);
+        // SMS alone is not strong enough for admins.
+        e.enroll(MfaMethod::Sms);
+        assert_eq!(policy.evaluate(Role::Admin, &e), PolicyDecision::AdminMfaRequired);
+        // TOTP satisfies the policy.
+        e.enroll(MfaMethod::Totp);
+        assert_eq!(policy.evaluate(Role::Admin, &e), PolicyDecision::Allow);
+    }
+
+    #[test]
+    fn user_mfa_optional_by_default() {
+        let policy = MfaPolicy::default();
+        let e = MfaEnrollment::none();
+        assert_eq!(policy.evaluate(Role::User, &e), PolicyDecision::Allow);
+        assert!(!policy.mfa_enforced(Role::User, &e));
+    }
+
+    #[test]
+    fn user_mfa_enforced_once_enrolled() {
+        let policy = MfaPolicy::default();
+        let mut e = MfaEnrollment::none();
+        e.enroll(MfaMethod::Totp);
+        assert!(policy.mfa_enforced(Role::User, &e));
+    }
+
+    #[test]
+    fn admin_mfa_always_enforced() {
+        let policy = MfaPolicy::default();
+        assert!(policy.mfa_enforced(Role::Admin, &MfaEnrollment::none()));
+    }
+
+    #[test]
+    fn required_user_policy_blocks_until_enrolled() {
+        let policy = MfaPolicy {
+            require_admin_mfa: true,
+            require_user_mfa: true,
+        };
+        let mut e = MfaEnrollment::none();
+        assert_eq!(policy.evaluate(Role::User, &e), PolicyDecision::UserMfaRequired);
+        e.enroll(MfaMethod::Sms);
+        assert_eq!(policy.evaluate(Role::User, &e), PolicyDecision::Allow);
+    }
+
+    #[test]
+    fn enrollment_enroll_remove_roundtrip() {
+        let mut e = MfaEnrollment::none();
+        e.enroll(MfaMethod::WebAuthn);
+        assert!(e.has(MfaMethod::WebAuthn));
+        assert!(e.has_strong());
+        e.remove(MfaMethod::WebAuthn);
+        assert!(!e.has(MfaMethod::WebAuthn));
+        assert!(!e.any());
+    }
+}

--- a/src/admin_mfa/session.rs
+++ b/src/admin_mfa/session.rs
@@ -1,0 +1,171 @@
+//! Admin session management with step-up re-authentication.
+//!
+//! A session records when MFA was last satisfied. Sensitive operations
+//! (verifying vulnerabilities, distributing bounties, changing security rules)
+//! require a *fresh* MFA assertion: if the last verification is older than the
+//! configured freshness window, the caller must re-authenticate before the
+//! operation proceeds.
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Operations classified by sensitivity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Sensitivity {
+    /// Routine read/navigation — only an active session is needed.
+    Normal,
+    /// High-impact actions — require recent MFA (step-up).
+    Sensitive,
+}
+
+/// Configuration for session lifetimes.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct SessionConfig {
+    /// Absolute session lifetime in seconds.
+    pub max_age_secs: i64,
+    /// Idle timeout in seconds.
+    pub idle_timeout_secs: i64,
+    /// How recent an MFA assertion must be to authorize a sensitive op.
+    pub step_up_freshness_secs: i64,
+}
+
+impl Default for SessionConfig {
+    fn default() -> Self {
+        Self {
+            max_age_secs: 8 * 3600,
+            idle_timeout_secs: 30 * 60,
+            step_up_freshness_secs: 5 * 60,
+        }
+    }
+}
+
+/// An authenticated admin session.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AdminSession {
+    /// Session identifier.
+    pub id: Uuid,
+    /// Owning account.
+    pub user: Uuid,
+    /// Creation timestamp (unix secs).
+    pub created_at: i64,
+    /// Last activity timestamp (unix secs).
+    pub last_activity: i64,
+    /// Last successful MFA timestamp (unix secs).
+    pub last_mfa_at: i64,
+}
+
+/// Why an operation was denied.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AccessDenied {
+    /// Session exceeded its absolute lifetime.
+    Expired,
+    /// Session idle too long.
+    IdleTimeout,
+    /// Sensitive operation needs a fresh MFA assertion.
+    StepUpRequired,
+}
+
+impl AdminSession {
+    /// Starts a session for `user` at `now`, with MFA just satisfied.
+    pub fn start(user: Uuid, now: i64) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            user,
+            created_at: now,
+            last_activity: now,
+            last_mfa_at: now,
+        }
+    }
+
+    /// Records that MFA was satisfied again (e.g. after a step-up challenge).
+    pub fn mark_mfa(&mut self, now: i64) {
+        self.last_mfa_at = now;
+        self.last_activity = now;
+    }
+
+    /// Records general activity, refreshing the idle timer.
+    pub fn touch(&mut self, now: i64) {
+        self.last_activity = now;
+    }
+
+    /// Authorizes an operation of the given sensitivity at `now`.
+    ///
+    /// On `Ok`, the idle timer is refreshed. On `Err`, the reason indicates
+    /// whether to terminate the session or merely demand a step-up challenge.
+    pub fn authorize(
+        &mut self,
+        sensitivity: Sensitivity,
+        cfg: &SessionConfig,
+        now: i64,
+    ) -> Result<(), AccessDenied> {
+        if now - self.created_at > cfg.max_age_secs {
+            return Err(AccessDenied::Expired);
+        }
+        if now - self.last_activity > cfg.idle_timeout_secs {
+            return Err(AccessDenied::IdleTimeout);
+        }
+        if sensitivity == Sensitivity::Sensitive
+            && now - self.last_mfa_at > cfg.step_up_freshness_secs
+        {
+            return Err(AccessDenied::StepUpRequired);
+        }
+        self.last_activity = now;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg() -> SessionConfig {
+        SessionConfig::default()
+    }
+
+    #[test]
+    fn normal_op_allowed_within_idle_window() {
+        let mut s = AdminSession::start(Uuid::new_v4(), 1000);
+        assert!(s.authorize(Sensitivity::Normal, &cfg(), 1000 + 60).is_ok());
+    }
+
+    #[test]
+    fn sensitive_op_requires_fresh_mfa() {
+        let mut s = AdminSession::start(Uuid::new_v4(), 1000);
+        // Within freshness window: allowed.
+        assert!(s.authorize(Sensitivity::Sensitive, &cfg(), 1000 + 60).is_ok());
+        // Past freshness window (but still active): step-up required.
+        let later = 1000 + cfg().step_up_freshness_secs + 1;
+        // Keep the session active so it's not idle-timed-out.
+        s.touch(later - 1);
+        assert_eq!(
+            s.authorize(Sensitivity::Sensitive, &cfg(), later),
+            Err(AccessDenied::StepUpRequired)
+        );
+        // After re-authenticating, the sensitive op proceeds.
+        s.mark_mfa(later);
+        assert!(s.authorize(Sensitivity::Sensitive, &cfg(), later).is_ok());
+    }
+
+    #[test]
+    fn idle_timeout_is_enforced() {
+        let mut s = AdminSession::start(Uuid::new_v4(), 1000);
+        let idle = 1000 + cfg().idle_timeout_secs + 1;
+        assert_eq!(
+            s.authorize(Sensitivity::Normal, &cfg(), idle),
+            Err(AccessDenied::IdleTimeout)
+        );
+    }
+
+    #[test]
+    fn absolute_expiry_is_enforced() {
+        let mut s = AdminSession::start(Uuid::new_v4(), 1000);
+        let expired = 1000 + cfg().max_age_secs + 1;
+        // Even with recent activity, absolute lifetime wins.
+        s.touch(expired - 1);
+        s.mark_mfa(expired - 1);
+        assert_eq!(
+            s.authorize(Sensitivity::Sensitive, &cfg(), expired),
+            Err(AccessDenied::Expired)
+        );
+    }
+}

--- a/src/admin_mfa/sms.rs
+++ b/src/admin_mfa/sms.rs
@@ -1,0 +1,195 @@
+//! SMS-based MFA fallback for users without a hardware token or authenticator.
+//!
+//! Generates a short numeric OTP, delivers it through a pluggable
+//! [`SmsSender`], and verifies it with an expiry and a bounded number of
+//! attempts to resist brute force. Only a hash of the OTP is retained.
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// Default OTP length in digits.
+pub const DEFAULT_OTP_DIGITS: u32 = 6;
+/// Default OTP lifetime in seconds.
+pub const DEFAULT_TTL_SECS: i64 = 300;
+/// Default maximum verification attempts before the OTP is invalidated.
+pub const DEFAULT_MAX_ATTEMPTS: u32 = 5;
+
+/// Delivers an SMS message. Production wires this to Twilio (a `reqwest`
+/// client already lives in the dependency tree); tests use a capturing double.
+pub trait SmsSender: Send + Sync {
+    /// Sends `message` to `phone`. Returns `Ok(())` on accepted delivery.
+    fn send(&self, phone: &str, message: &str) -> Result<(), String>;
+}
+
+/// A pending SMS challenge (stores only the OTP hash).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SmsChallenge {
+    /// Destination phone number.
+    pub phone: String,
+    otp_hash: String,
+    /// Unix expiry timestamp (seconds).
+    pub expires_at: i64,
+    attempts: u32,
+    max_attempts: u32,
+}
+
+/// Outcome of verifying an SMS OTP.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SmsVerifyResult {
+    /// The OTP matched.
+    Verified,
+    /// Wrong code; `remaining` attempts left before lockout.
+    Incorrect {
+        /// Attempts remaining before the challenge is invalidated.
+        remaining: u32,
+    },
+    /// The OTP has expired.
+    Expired,
+    /// Too many wrong attempts; the challenge is now invalid.
+    TooManyAttempts,
+}
+
+impl SmsChallenge {
+    /// Generates an OTP, sends it via `sender`, and returns the stored
+    /// challenge. The plaintext OTP never leaves this function except over SMS.
+    pub fn issue(
+        phone: impl Into<String>,
+        now: i64,
+        rng: &mut impl rand::RngCore,
+        sender: &dyn SmsSender,
+    ) -> Result<Self, String> {
+        let phone = phone.into();
+        let otp = generate_otp(DEFAULT_OTP_DIGITS, rng);
+        sender.send(&phone, &format!("Your verification code is {otp}"))?;
+        Ok(Self {
+            phone,
+            otp_hash: hash(&otp),
+            expires_at: now + DEFAULT_TTL_SECS,
+            attempts: 0,
+            max_attempts: DEFAULT_MAX_ATTEMPTS,
+        })
+    }
+
+    /// Verifies a submitted code at `now`.
+    pub fn verify(&mut self, code: &str, now: i64) -> SmsVerifyResult {
+        if now > self.expires_at {
+            return SmsVerifyResult::Expired;
+        }
+        if self.attempts >= self.max_attempts {
+            return SmsVerifyResult::TooManyAttempts;
+        }
+        self.attempts += 1;
+        if constant_time_eq(hash(code.trim()).as_bytes(), self.otp_hash.as_bytes()) {
+            SmsVerifyResult::Verified
+        } else if self.attempts >= self.max_attempts {
+            SmsVerifyResult::TooManyAttempts
+        } else {
+            SmsVerifyResult::Incorrect {
+                remaining: self.max_attempts - self.attempts,
+            }
+        }
+    }
+}
+
+fn generate_otp(digits: u32, rng: &mut impl rand::RngCore) -> String {
+    let modulo = 10u32.pow(digits);
+    let value = rng.next_u32() % modulo;
+    format!("{:0width$}", value, width = digits as usize)
+}
+
+fn hash(code: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(code.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Captures the last sent message so the test can read the OTP.
+    #[derive(Default)]
+    struct CapturingSender(Mutex<Option<String>>);
+
+    impl SmsSender for CapturingSender {
+        fn send(&self, _phone: &str, message: &str) -> Result<(), String> {
+            *self.0.lock().unwrap() = Some(message.to_string());
+            Ok(())
+        }
+    }
+
+    fn extract_otp(sender: &CapturingSender) -> String {
+        let msg = sender.0.lock().unwrap().clone().unwrap();
+        msg.chars().filter(|c| c.is_ascii_digit()).collect()
+    }
+
+    #[test]
+    fn correct_code_verifies() {
+        let mut rng = rand::rngs::OsRng;
+        let sender = CapturingSender::default();
+        let mut ch = SmsChallenge::issue("+15551234567", 1000, &mut rng, &sender).unwrap();
+        let otp = extract_otp(&sender);
+        assert_eq!(ch.verify(&otp, 1100), SmsVerifyResult::Verified);
+    }
+
+    #[test]
+    fn wrong_code_decrements_attempts() {
+        let mut rng = rand::rngs::OsRng;
+        let sender = CapturingSender::default();
+        let mut ch = SmsChallenge::issue("+15551234567", 1000, &mut rng, &sender).unwrap();
+        match ch.verify("000000", 1100) {
+            // Could coincidentally be correct (1-in-a-million); treat that as fine.
+            SmsVerifyResult::Verified => {}
+            SmsVerifyResult::Incorrect { remaining } => {
+                assert_eq!(remaining, DEFAULT_MAX_ATTEMPTS - 1)
+            }
+            other => panic!("unexpected {other:?}"),
+        }
+    }
+
+    #[test]
+    fn expired_code_is_rejected() {
+        let mut rng = rand::rngs::OsRng;
+        let sender = CapturingSender::default();
+        let mut ch = SmsChallenge::issue("+15551234567", 1000, &mut rng, &sender).unwrap();
+        let otp = extract_otp(&sender);
+        assert_eq!(ch.verify(&otp, 1000 + DEFAULT_TTL_SECS + 1), SmsVerifyResult::Expired);
+    }
+
+    #[test]
+    fn lockout_after_max_attempts() {
+        let mut rng = rand::rngs::OsRng;
+        let sender = CapturingSender::default();
+        let mut ch = SmsChallenge::issue("+15551234567", 1000, &mut rng, &sender).unwrap();
+        // Use an obviously-wrong code repeatedly. Use a value unlikely to match.
+        let wrong = "999999";
+        let real = extract_otp(&sender);
+        let wrong = if wrong == real { "111111" } else { wrong };
+        for _ in 0..DEFAULT_MAX_ATTEMPTS {
+            let _ = ch.verify(wrong, 1100);
+        }
+        assert_eq!(ch.verify(wrong, 1100), SmsVerifyResult::TooManyAttempts);
+    }
+
+    #[test]
+    fn otp_plaintext_is_not_stored() {
+        let mut rng = rand::rngs::OsRng;
+        let sender = CapturingSender::default();
+        let ch = SmsChallenge::issue("+15551234567", 1000, &mut rng, &sender).unwrap();
+        let otp = extract_otp(&sender);
+        let json = serde_json::to_string(&ch).unwrap();
+        assert!(!json.contains(&otp));
+    }
+}

--- a/src/admin_mfa/tests.rs
+++ b/src/admin_mfa/tests.rs
@@ -1,0 +1,143 @@
+//! End-to-end integration tests spanning the MFA subsystem: full admin
+//! lifecycle, step-up re-auth, anomaly-driven challenges and emergency bypass.
+
+use super::*;
+use uuid::Uuid;
+
+fn ctx(ip: &str, device: &str, location: &str, hour: u8) -> LoginContext {
+    LoginContext {
+        ip: ip.to_string(),
+        device_fingerprint: device.to_string(),
+        location: location.to_string(),
+        hour_utc: hour,
+    }
+}
+
+#[test]
+fn full_admin_mfa_lifecycle() {
+    let mut mgr = MfaManager::new(MfaPolicy::default());
+    let admin = Uuid::new_v4();
+    mgr.add_account(admin, Role::Admin);
+    let mut rng = rand::rngs::OsRng;
+
+    // 1. Before enrollment, policy blocks the admin.
+    let pre = mgr.begin_login(admin, ctx("203.0.113.1", "dev-A", "US-CA", 9), 1000).unwrap();
+    assert_eq!(pre.policy, PolicyDecision::AdminMfaRequired);
+
+    // 2. Enroll TOTP and confirm.
+    let setup = mgr.setup_totp(admin, "Soroban", "admin@example.com", &mut rng).unwrap();
+    let totp = TotpConfig::from_secret(base32::decode(&setup.secret_base32).unwrap());
+    let t = 1_700_000_000u64;
+    assert!(mgr.confirm_totp(admin, &totp.code_at(t), t));
+
+    // 3. Issue recovery backup codes.
+    let codes = mgr.generate_backup_codes(admin, 10, &mut rng).unwrap();
+    assert_eq!(codes.len(), 10);
+
+    // 4. Policy now clears; MFA is still required (admins always step up).
+    let post = mgr.begin_login(admin, ctx("203.0.113.1", "dev-A", "US-CA", 9), t as i64).unwrap();
+    assert_eq!(post.policy, PolicyDecision::Allow);
+    assert!(post.mfa_required);
+
+    // 5. Verify the second factor.
+    let later = t + 60;
+    assert!(mgr.verify_totp(admin, &totp.code_at(later), later));
+
+    // 6. Recovery path: a backup code works when the device is lost.
+    assert!(mgr.redeem_backup_code(admin, &codes[0]));
+    assert_eq!(mgr.backup_codes_remaining(admin), 9);
+}
+
+#[test]
+fn step_up_required_for_sensitive_admin_operation() {
+    let user = Uuid::new_v4();
+    let cfg = SessionConfig::default();
+    let mut session = AdminSession::start(user, 1000);
+
+    // Routine work is fine.
+    assert!(session.authorize(Sensitivity::Normal, &cfg, 1000 + 60).is_ok());
+
+    // A sensitive action after the freshness window demands re-auth.
+    let stale = 1000 + cfg.step_up_freshness_secs + 10;
+    session.touch(stale - 1);
+    assert_eq!(
+        session.authorize(Sensitivity::Sensitive, &cfg, stale),
+        Err(AccessDenied::StepUpRequired)
+    );
+
+    // Re-authenticate (MFA), then the action proceeds.
+    session.mark_mfa(stale);
+    assert!(session.authorize(Sensitivity::Sensitive, &cfg, stale).is_ok());
+}
+
+#[test]
+fn suspicious_login_triggers_challenge_then_webauthn_clears_it() {
+    let mut mgr = MfaManager::new(MfaPolicy::default());
+    let admin = Uuid::new_v4();
+    mgr.add_account(admin, Role::Admin);
+
+    // Register a hardware key.
+    let credential = RegisteredCredential {
+        credential_id: vec![1, 2, 3],
+        public_key: vec![9],
+        sign_count: 1,
+        label: "YubiKey".to_string(),
+    };
+    assert!(mgr.register_webauthn(admin, credential));
+
+    // Baseline a normal login, then attempt from a new country/device.
+    mgr.begin_login(admin, ctx("203.0.113.1", "dev-A", "US-CA", 9), 1000);
+    let decision = mgr
+        .begin_login(admin, ctx("8.8.8.8", "dev-Z", "RU-MOW", 3), 2000)
+        .unwrap();
+    assert_eq!(decision.anomaly.level, RiskLevel::High);
+    assert!(decision.mfa_required);
+
+    // Satisfy the challenge with the hardware key.
+    let challenge = mgr.webauthn_mut().issue_challenge(vec![5; 32], 2000, 300);
+    let response = AssertionResponse {
+        credential_id: vec![1, 2, 3],
+        sign_count: 2,
+        signature: vec![0xaa],
+        challenge: vec![5; 32],
+    };
+    assert!(mgr
+        .verify_webauthn(admin, challenge.id, &response, &AcceptingVerifier, 2010)
+        .is_ok());
+}
+
+#[test]
+fn emergency_bypass_requires_multiple_admins() {
+    let target = Uuid::new_v4();
+    let admin_a = Uuid::new_v4();
+    let admin_b = Uuid::new_v4();
+    let cfg = EmergencyConfig::default(); // quorum 2
+
+    let mut req = BypassRequest::open(target, admin_a, 1000, cfg).unwrap();
+    assert_eq!(req.status, BypassStatus::Pending);
+    assert!(!req.is_bypass_active(1000));
+
+    // A single second admin reaches quorum and grants a time-boxed bypass.
+    req.approve(admin_b, 1000).unwrap();
+    assert!(req.is_bypass_active(1000));
+
+    // The grant is one-time and expires.
+    assert!(req.consume(1000));
+    assert!(!req.is_bypass_active(1000));
+}
+
+#[test]
+fn regular_user_can_login_without_mfa_until_enrolled() {
+    let mut mgr = MfaManager::new(MfaPolicy::default());
+    let user = Uuid::new_v4();
+    mgr.add_account(user, Role::User);
+
+    // First login establishes baseline (elevated), second is clear.
+    mgr.begin_login(user, ctx("203.0.113.5", "dev-U", "US-NY", 14), 1000);
+    let decision = mgr
+        .begin_login(user, ctx("203.0.113.5", "dev-U", "US-NY", 14), 1100)
+        .unwrap();
+    assert_eq!(decision.policy, PolicyDecision::Allow);
+    assert!(!decision.mfa_required);
+    assert!(decision.is_clear());
+}

--- a/src/admin_mfa/totp.rs
+++ b/src/admin_mfa/totp.rs
@@ -1,0 +1,225 @@
+//! TOTP (Time-based One-Time Password) per RFC 6238 / HOTP per RFC 4226.
+//!
+//! Uses HMAC-SHA1 (the algorithm understood by every mainstream authenticator
+//! app) via `ring`, with a configurable digit count, time step and skew
+//! window. Verification is anti-replay aware: a verified counter is reported so
+//! the caller can refuse to honour the same step twice.
+
+use crate::admin_mfa::base32;
+use ring::hmac;
+use serde::{Deserialize, Serialize};
+
+/// Default number of digits in a generated code.
+pub const DEFAULT_DIGITS: u32 = 6;
+/// Default time step in seconds.
+pub const DEFAULT_STEP_SECS: u64 = 30;
+/// Default verification skew window (steps checked on each side of "now").
+pub const DEFAULT_SKEW_STEPS: u64 = 1;
+/// Recommended shared-secret length in bytes (160-bit, per RFC 4226).
+pub const SECRET_LEN: usize = 20;
+
+/// A TOTP configuration bound to a shared secret.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TotpConfig {
+    /// Raw shared secret bytes.
+    pub secret: Vec<u8>,
+    /// Number of digits per code.
+    pub digits: u32,
+    /// Time step in seconds.
+    pub step_secs: u64,
+    /// Number of steps tolerated on each side of the current step.
+    pub skew_steps: u64,
+}
+
+impl TotpConfig {
+    /// Builds a config from raw secret bytes with default parameters.
+    pub fn from_secret(secret: Vec<u8>) -> Self {
+        Self {
+            secret,
+            digits: DEFAULT_DIGITS,
+            step_secs: DEFAULT_STEP_SECS,
+            skew_steps: DEFAULT_SKEW_STEPS,
+        }
+    }
+
+    /// Generates a fresh random-secret config using the supplied RNG.
+    ///
+    /// The RNG is injected so callers can use a CSPRNG in production and a
+    /// deterministic source in tests.
+    pub fn generate(rng: &mut impl rand::RngCore) -> Self {
+        let mut secret = vec![0u8; SECRET_LEN];
+        rng.fill_bytes(&mut secret);
+        Self::from_secret(secret)
+    }
+
+    /// Returns the secret as a base32 string for manual entry.
+    pub fn secret_base32(&self) -> String {
+        base32::encode(&self.secret)
+    }
+
+    /// Builds an `otpauth://` provisioning URI for QR-code enrollment.
+    pub fn provisioning_uri(&self, issuer: &str, account: &str) -> String {
+        let label = format!("{issuer}:{account}");
+        format!(
+            "otpauth://totp/{}?secret={}&issuer={}&algorithm=SHA1&digits={}&period={}",
+            urlencode(&label),
+            self.secret_base32(),
+            urlencode(issuer),
+            self.digits,
+            self.step_secs
+        )
+    }
+
+    /// Computes the code for an explicit unix timestamp (seconds).
+    pub fn code_at(&self, unix_secs: u64) -> String {
+        let counter = unix_secs / self.step_secs;
+        let value = hotp(&self.secret, counter, self.digits);
+        zero_pad(value, self.digits)
+    }
+
+    /// Verifies a code at `unix_secs`, scanning the skew window.
+    ///
+    /// Returns the matching counter on success so the caller can persist it and
+    /// reject replays of the same or earlier step.
+    pub fn verify_at(&self, code: &str, unix_secs: u64) -> Option<u64> {
+        let trimmed = code.trim();
+        if trimmed.len() != self.digits as usize || !trimmed.bytes().all(|b| b.is_ascii_digit()) {
+            return None;
+        }
+        let center = unix_secs / self.step_secs;
+        let skew = self.skew_steps;
+        // Iterate oldest→newest within the window.
+        for counter in center.saturating_sub(skew)..=center + skew {
+            let candidate = zero_pad(hotp(&self.secret, counter, self.digits), self.digits);
+            if constant_time_eq(candidate.as_bytes(), trimmed.as_bytes()) {
+                return Some(counter);
+            }
+        }
+        None
+    }
+}
+
+/// RFC 4226 HOTP value for a counter.
+fn hotp(secret: &[u8], counter: u64, digits: u32) -> u32 {
+    let key = hmac::Key::new(hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY, secret);
+    let tag = hmac::sign(&key, &counter.to_be_bytes());
+    let hs = tag.as_ref();
+    let offset = (hs[hs.len() - 1] & 0x0f) as usize;
+    let bin = (((hs[offset] & 0x7f) as u32) << 24)
+        | ((hs[offset + 1] as u32) << 16)
+        | ((hs[offset + 2] as u32) << 8)
+        | (hs[offset + 3] as u32);
+    bin % 10u32.pow(digits)
+}
+
+fn zero_pad(value: u32, digits: u32) -> String {
+    format!("{:0width$}", value, width = digits as usize)
+}
+
+/// Constant-time byte comparison to avoid timing oracles on code checks.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+/// Percent-encodes the characters that matter inside otpauth labels.
+fn urlencode(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for b in input.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char)
+            }
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// RFC 6238 Appendix B test vector secret ("12345678901234567890").
+    fn rfc_secret() -> Vec<u8> {
+        b"12345678901234567890".to_vec()
+    }
+
+    #[test]
+    fn rfc6238_test_vectors_sha1() {
+        // 8-digit codes at the documented timestamps.
+        let cfg = TotpConfig {
+            secret: rfc_secret(),
+            digits: 8,
+            step_secs: 30,
+            skew_steps: 0,
+        };
+        assert_eq!(cfg.code_at(59), "94287082");
+        assert_eq!(cfg.code_at(1111111109), "07081804");
+        assert_eq!(cfg.code_at(1234567890), "89005924");
+    }
+
+    #[test]
+    fn verify_accepts_current_code() {
+        let cfg = TotpConfig::from_secret(rfc_secret());
+        let now = 1_700_000_000;
+        let code = cfg.code_at(now);
+        assert!(cfg.verify_at(&code, now).is_some());
+    }
+
+    #[test]
+    fn verify_honours_skew_window() {
+        let cfg = TotpConfig::from_secret(rfc_secret()); // skew = 1 step
+        let now = 1_700_000_000;
+        let prev_step = now - DEFAULT_STEP_SECS as u64;
+        let code = cfg.code_at(prev_step);
+        // A code from the previous step is still accepted within skew.
+        assert!(cfg.verify_at(&code, now).is_some());
+        // Two steps in the past is rejected.
+        let old = cfg.code_at(now - 2 * DEFAULT_STEP_SECS as u64);
+        assert!(cfg.verify_at(&old, now).is_none());
+    }
+
+    #[test]
+    fn verify_rejects_malformed() {
+        let cfg = TotpConfig::from_secret(rfc_secret());
+        assert!(cfg.verify_at("12345", 0).is_none()); // too short
+        assert!(cfg.verify_at("abcdef", 0).is_none()); // non-digit
+    }
+
+    #[test]
+    fn verify_returns_counter_for_replay_detection() {
+        let cfg = TotpConfig::from_secret(rfc_secret());
+        let now = 1_700_000_000;
+        let counter = cfg.verify_at(&cfg.code_at(now), now).unwrap();
+        assert_eq!(counter, now / DEFAULT_STEP_SECS as u64);
+    }
+
+    #[test]
+    fn provisioning_uri_is_well_formed() {
+        let cfg = TotpConfig::from_secret(rfc_secret());
+        let uri = cfg.provisioning_uri("Soroban Scanner", "admin@example.com");
+        assert!(uri.starts_with("otpauth://totp/"));
+        assert!(uri.contains("secret="));
+        assert!(uri.contains("algorithm=SHA1"));
+        assert!(uri.contains("digits=6"));
+        assert!(uri.contains("period=30"));
+        // Spaces and @ are percent-encoded.
+        assert!(!uri.contains(' '));
+    }
+
+    #[test]
+    fn generate_produces_verifiable_secret() {
+        let mut rng = rand::rngs::OsRng;
+        let cfg = TotpConfig::generate(&mut rng);
+        assert_eq!(cfg.secret.len(), SECRET_LEN);
+        let now = 1_700_000_000;
+        assert!(cfg.verify_at(&cfg.code_at(now), now).is_some());
+    }
+}

--- a/src/admin_mfa/webauthn.rs
+++ b/src/admin_mfa/webauthn.rs
@@ -1,0 +1,290 @@
+//! FIDO2 / WebAuthn second-factor support (hardware security keys, e.g. YubiKey).
+//!
+//! This implements the WebAuthn *ceremony* state machine — challenge issuance,
+//! credential registration, assertion verification, and the cloned-authenticator
+//! check via the signature counter (per the WebAuthn spec §6.1.1). The
+//! cryptographic signature check itself is delegated to a pluggable
+//! [`AssertionVerifier`] so a production deployment can wire in a full COSE/CBOR
+//! verifier without this module pulling in a heavy crypto stack.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use uuid::Uuid;
+
+/// A registered WebAuthn credential (one hardware key per record).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RegisteredCredential {
+    /// Opaque credential id from the authenticator.
+    pub credential_id: Vec<u8>,
+    /// COSE-encoded public key bytes.
+    pub public_key: Vec<u8>,
+    /// Last seen signature counter (monotonic; detects cloned keys).
+    pub sign_count: u32,
+    /// Friendly label ("YubiKey 5C", "Work laptop", …).
+    pub label: String,
+}
+
+/// A pending registration or authentication challenge.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WebAuthnChallenge {
+    /// Unique challenge id.
+    pub id: Uuid,
+    /// Random challenge bytes the authenticator must sign.
+    pub challenge: Vec<u8>,
+    /// Unix expiry timestamp (seconds).
+    pub expires_at: i64,
+}
+
+/// Data returned by the client after an authentication ceremony.
+#[derive(Debug, Clone)]
+pub struct AssertionResponse {
+    /// Which credential was used.
+    pub credential_id: Vec<u8>,
+    /// Authenticator signature counter from this assertion.
+    pub sign_count: u32,
+    /// The raw signature over (authenticatorData || clientDataHash).
+    pub signature: Vec<u8>,
+    /// The challenge bytes echoed by the client.
+    pub challenge: Vec<u8>,
+}
+
+/// Errors surfaced by the WebAuthn factor.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WebAuthnError {
+    /// No challenge matched (unknown, already consumed, or wrong value).
+    UnknownChallenge,
+    /// The challenge has expired.
+    ChallengeExpired,
+    /// The referenced credential is not registered.
+    UnknownCredential,
+    /// The signature failed cryptographic verification.
+    BadSignature,
+    /// The signature counter did not increase — possible cloned authenticator.
+    CounterRollback,
+}
+
+/// Delegated signature verification. Implement against a real COSE verifier in
+/// production; the default test double accepts any non-empty signature.
+pub trait AssertionVerifier: Send + Sync {
+    /// Verifies `signature` for `credential` over `challenge`.
+    fn verify(&self, credential: &RegisteredCredential, challenge: &[u8], signature: &[u8]) -> bool;
+}
+
+/// A permissive verifier used in tests and as a wiring placeholder. It checks
+/// only that a signature is present — **never** use it in production.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct AcceptingVerifier;
+
+impl AssertionVerifier for AcceptingVerifier {
+    fn verify(&self, _credential: &RegisteredCredential, _challenge: &[u8], signature: &[u8]) -> bool {
+        !signature.is_empty()
+    }
+}
+
+/// Per-user store of credentials and outstanding challenges.
+#[derive(Default)]
+pub struct WebAuthnRegistry {
+    credentials: HashMap<Uuid, Vec<RegisteredCredential>>,
+    challenges: HashMap<Uuid, WebAuthnChallenge>,
+}
+
+impl WebAuthnRegistry {
+    /// Creates an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Issues a challenge valid for `ttl_secs` from `now`.
+    pub fn issue_challenge(
+        &mut self,
+        challenge_bytes: Vec<u8>,
+        now: i64,
+        ttl_secs: i64,
+    ) -> WebAuthnChallenge {
+        let challenge = WebAuthnChallenge {
+            id: Uuid::new_v4(),
+            challenge: challenge_bytes,
+            expires_at: now + ttl_secs,
+        };
+        self.challenges.insert(challenge.id, challenge.clone());
+        challenge
+    }
+
+    /// Registers a new credential for a user after a successful registration
+    /// ceremony.
+    pub fn register(&mut self, user: Uuid, credential: RegisteredCredential) {
+        self.credentials.entry(user).or_default().push(credential);
+    }
+
+    /// Returns true if the user has at least one hardware key registered.
+    pub fn has_credential(&self, user: Uuid) -> bool {
+        self.credentials.get(&user).is_some_and(|c| !c.is_empty())
+    }
+
+    /// Lists a user's registered credentials.
+    pub fn credentials(&self, user: Uuid) -> &[RegisteredCredential] {
+        self.credentials.get(&user).map(|v| v.as_slice()).unwrap_or(&[])
+    }
+
+    /// Verifies an authentication assertion, consuming the matching challenge,
+    /// checking the signature and enforcing counter monotonicity.
+    pub fn verify_assertion(
+        &mut self,
+        user: Uuid,
+        challenge_id: Uuid,
+        response: &AssertionResponse,
+        verifier: &dyn AssertionVerifier,
+        now: i64,
+    ) -> Result<(), WebAuthnError> {
+        // 1. Consume the challenge (single use) and validate it.
+        let challenge = self
+            .challenges
+            .remove(&challenge_id)
+            .ok_or(WebAuthnError::UnknownChallenge)?;
+        if challenge.expires_at < now {
+            return Err(WebAuthnError::ChallengeExpired);
+        }
+        if challenge.challenge != response.challenge {
+            return Err(WebAuthnError::UnknownChallenge);
+        }
+
+        // 2. Locate the credential.
+        let creds = self
+            .credentials
+            .get_mut(&user)
+            .ok_or(WebAuthnError::UnknownCredential)?;
+        let cred = creds
+            .iter_mut()
+            .find(|c| c.credential_id == response.credential_id)
+            .ok_or(WebAuthnError::UnknownCredential)?;
+
+        // 3. Verify the signature.
+        if !verifier.verify(cred, &challenge.challenge, &response.signature) {
+            return Err(WebAuthnError::BadSignature);
+        }
+
+        // 4. Cloned-authenticator detection (counter must strictly increase,
+        //    unless the authenticator does not support counters and reports 0).
+        if response.sign_count != 0 && response.sign_count <= cred.sign_count {
+            return Err(WebAuthnError::CounterRollback);
+        }
+        cred.sign_count = response.sign_count;
+        Ok(())
+    }
+
+    /// Drops expired challenges (housekeeping).
+    pub fn prune_challenges(&mut self, now: i64) {
+        self.challenges.retain(|_, c| c.expires_at >= now);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn credential() -> RegisteredCredential {
+        RegisteredCredential {
+            credential_id: vec![1, 2, 3, 4],
+            public_key: vec![9, 9, 9],
+            sign_count: 5,
+            label: "YubiKey 5C".to_string(),
+        }
+    }
+
+    fn registry_with_user() -> (WebAuthnRegistry, Uuid) {
+        let mut reg = WebAuthnRegistry::new();
+        let user = Uuid::new_v4();
+        reg.register(user, credential());
+        (reg, user)
+    }
+
+    #[test]
+    fn registration_tracks_credentials() {
+        let (reg, user) = registry_with_user();
+        assert!(reg.has_credential(user));
+        assert_eq!(reg.credentials(user).len(), 1);
+        assert!(!reg.has_credential(Uuid::new_v4()));
+    }
+
+    #[test]
+    fn valid_assertion_succeeds_and_advances_counter() {
+        let (mut reg, user) = registry_with_user();
+        let ch = reg.issue_challenge(vec![7; 32], 1000, 300);
+        let resp = AssertionResponse {
+            credential_id: vec![1, 2, 3, 4],
+            sign_count: 6,
+            signature: vec![0xaa],
+            challenge: vec![7; 32],
+        };
+        assert!(reg
+            .verify_assertion(user, ch.id, &resp, &AcceptingVerifier, 1100)
+            .is_ok());
+        assert_eq!(reg.credentials(user)[0].sign_count, 6);
+    }
+
+    #[test]
+    fn counter_rollback_is_rejected() {
+        let (mut reg, user) = registry_with_user(); // counter 5
+        let ch = reg.issue_challenge(vec![7; 32], 1000, 300);
+        let resp = AssertionResponse {
+            credential_id: vec![1, 2, 3, 4],
+            sign_count: 5, // not greater than stored 5
+            signature: vec![0xaa],
+            challenge: vec![7; 32],
+        };
+        assert_eq!(
+            reg.verify_assertion(user, ch.id, &resp, &AcceptingVerifier, 1100),
+            Err(WebAuthnError::CounterRollback)
+        );
+    }
+
+    #[test]
+    fn expired_challenge_is_rejected() {
+        let (mut reg, user) = registry_with_user();
+        let ch = reg.issue_challenge(vec![7; 32], 1000, 100);
+        let resp = AssertionResponse {
+            credential_id: vec![1, 2, 3, 4],
+            sign_count: 6,
+            signature: vec![0xaa],
+            challenge: vec![7; 32],
+        };
+        assert_eq!(
+            reg.verify_assertion(user, ch.id, &resp, &AcceptingVerifier, 2000),
+            Err(WebAuthnError::ChallengeExpired)
+        );
+    }
+
+    #[test]
+    fn challenge_is_single_use() {
+        let (mut reg, user) = registry_with_user();
+        let ch = reg.issue_challenge(vec![7; 32], 1000, 300);
+        let resp = AssertionResponse {
+            credential_id: vec![1, 2, 3, 4],
+            sign_count: 6,
+            signature: vec![0xaa],
+            challenge: vec![7; 32],
+        };
+        assert!(reg.verify_assertion(user, ch.id, &resp, &AcceptingVerifier, 1100).is_ok());
+        // Re-use of the same challenge id now fails.
+        assert_eq!(
+            reg.verify_assertion(user, ch.id, &resp, &AcceptingVerifier, 1100),
+            Err(WebAuthnError::UnknownChallenge)
+        );
+    }
+
+    #[test]
+    fn bad_signature_is_rejected() {
+        let (mut reg, user) = registry_with_user();
+        let ch = reg.issue_challenge(vec![7; 32], 1000, 300);
+        let resp = AssertionResponse {
+            credential_id: vec![1, 2, 3, 4],
+            sign_count: 6,
+            signature: vec![], // empty → AcceptingVerifier rejects
+            challenge: vec![7; 32],
+        };
+        assert_eq!(
+            reg.verify_assertion(user, ch.id, &resp, &AcceptingVerifier, 1100),
+            Err(WebAuthnError::BadSignature)
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,10 @@ impl Severity {
 // The api_versioning module compiles cleanly without the broken-modules feature.
 pub mod api_versioning;
 
+// Multi-factor authentication for administrative access (issue #328).
+// Self-contained and compiles cleanly under default features.
+pub mod admin_mfa;
+
 // === Broken modules gated behind feature flag ===
 // Each module has pre-existing compilation errors (borrow checker violations,
 // missing trait impls, type mismatches, unresolved imports) that are being


### PR DESCRIPTION
# Multi-Factor Authentication for administrative access (#328)

Closes #328.

## Acceptance criteria

| # | Requirement | Status |
|---|-------------|--------|
| 1 | TOTP MFA using RFC 6238 | ✅ `totp::TotpConfig` (HMAC-SHA1, skew window, anti-replay) |
| 2 | Hardware security keys (FIDO2/WebAuthn) | ✅ `webauthn::WebAuthnRegistry` |
| 3 | SMS-based MFA fallback | ✅ `sms::SmsChallenge` (+ `SmsSender` abstraction) |
| 4 | MFA enforced for admins, optional for users | ✅ `policy::MfaPolicy` |
| 5 | Setup & recovery workflows with backup codes | ✅ `backup_codes::BackupCodeSet`, `manager` setup/confirm flows |
| 6 | Session anomaly detection (location/device/IP/time) | ✅ `anomaly::AnomalyDetector` |
| 7 | Automatic MFA challenge for suspicious logins | ✅ `manager::MfaManager::begin_login` |
| 8 | Admin session mgmt + forced re-auth for sensitive ops | ✅ `session::AdminSession` (step-up) |
| 9 | Emergency bypass with multi-admin approval | ✅ `emergency::BypassRequest` (M-of-N quorum) |
| 10 | 100% MFA coverage for admins | ✅ admins cannot clear policy without a strong factor |
| 11 | Comprehensive security testing | ✅ 62 tests |
| 12 | Document MFA policies & procedures | ✅ module + per-type rustdoc, acceptance-criteria map in `mod.rs` |
