### PR TITLE
feat(security): input sanitization for contract-code uploads (#330)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,10 @@ impl Severity {
 // The api_versioning module compiles cleanly without the broken-modules feature.
 pub mod api_versioning;
 
+// Input sanitization & validation for contract-code uploads (issue #330).
+// Self-contained and compiles cleanly under default features.
+pub mod upload_sanitization;
+
 // === Broken modules gated behind feature flag ===
 // Each module has pre-existing compilation errors (borrow checker violations,
 // missing trait impls, type mismatches, unresolved imports) that are being

--- a/src/upload_sanitization/content_type.rs
+++ b/src/upload_sanitization/content_type.rs
@@ -24,7 +24,12 @@ pub enum AllowedContentType {
 impl AllowedContentType {
     /// Parses a declared MIME type (case-insensitive, parameters ignored).
     pub fn parse(mime: &str) -> Option<Self> {
-        let base = mime.split(';').next().unwrap_or("").trim().to_ascii_lowercase();
+        let base = mime
+            .split(';')
+            .next()
+            .unwrap_or("")
+            .trim()
+            .to_ascii_lowercase();
         match base.as_str() {
             "application/wasm" => Some(Self::Wasm),
             "text/rust" | "text/x-rust" | "application/rust" => Some(Self::RustSource),
@@ -80,7 +85,10 @@ mod tests {
 
     #[test]
     fn allowlist_parsing() {
-        assert_eq!(AllowedContentType::parse("application/wasm"), Some(AllowedContentType::Wasm));
+        assert_eq!(
+            AllowedContentType::parse("application/wasm"),
+            Some(AllowedContentType::Wasm)
+        );
         assert_eq!(
             AllowedContentType::parse("text/x-rust; charset=utf-8"),
             Some(AllowedContentType::RustSource)
@@ -103,7 +111,10 @@ mod tests {
 
     #[test]
     fn disallowed_type_is_rejected() {
-        assert_eq!(check("application/x-msdownload", FileKind::Wasm), ContentTypeCheck::NotAllowed);
+        assert_eq!(
+            check("application/x-msdownload", FileKind::Wasm),
+            ContentTypeCheck::NotAllowed
+        );
     }
 
     #[test]

--- a/src/upload_sanitization/content_type.rs
+++ b/src/upload_sanitization/content_type.rs
@@ -1,0 +1,120 @@
+//! Content-type allowlisting and consistency checks.
+//!
+//! Only a small set of declared content types is accepted, and the declared
+//! type must be *consistent* with the kind sniffed from the bytes — a request
+//! that claims `application/wasm` but whose bytes are an ELF binary is
+//! rejected.
+
+use crate::upload_sanitization::magic::FileKind;
+use serde::{Deserialize, Serialize};
+
+/// A declared, allowlisted content type for contract-code uploads.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AllowedContentType {
+    /// `application/wasm`.
+    Wasm,
+    /// `text/rust` / `text/x-rust` — Rust source.
+    RustSource,
+    /// `text/x-toml` / `application/toml` — Cargo manifest.
+    Toml,
+    /// `text/plain` — generic source text.
+    PlainText,
+}
+
+impl AllowedContentType {
+    /// Parses a declared MIME type (case-insensitive, parameters ignored).
+    pub fn parse(mime: &str) -> Option<Self> {
+        let base = mime.split(';').next().unwrap_or("").trim().to_ascii_lowercase();
+        match base.as_str() {
+            "application/wasm" => Some(Self::Wasm),
+            "text/rust" | "text/x-rust" | "application/rust" => Some(Self::RustSource),
+            "text/x-toml" | "application/toml" | "text/toml" => Some(Self::Toml),
+            "text/plain" => Some(Self::PlainText),
+            _ => None,
+        }
+    }
+
+    /// The file kind the declared type implies.
+    pub fn expected_kind(&self) -> FileKind {
+        match self {
+            AllowedContentType::Wasm => FileKind::Wasm,
+            AllowedContentType::RustSource
+            | AllowedContentType::Toml
+            | AllowedContentType::PlainText => FileKind::SourceText,
+        }
+    }
+}
+
+/// Result of validating a declared content type against sniffed bytes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContentTypeCheck {
+    /// Declared type is allowlisted and matches the detected kind.
+    Ok(AllowedContentType),
+    /// Declared type is not on the allowlist.
+    NotAllowed,
+    /// Declared type is allowlisted but contradicts the detected bytes.
+    Mismatch {
+        /// What the bytes actually look like.
+        detected: FileKind,
+        /// What the declaration implied.
+        expected: FileKind,
+    },
+}
+
+/// Validates a declared MIME type against the detected file kind.
+pub fn check(declared_mime: &str, detected: FileKind) -> ContentTypeCheck {
+    let Some(allowed) = AllowedContentType::parse(declared_mime) else {
+        return ContentTypeCheck::NotAllowed;
+    };
+    let expected = allowed.expected_kind();
+    if expected == detected {
+        ContentTypeCheck::Ok(allowed)
+    } else {
+        ContentTypeCheck::Mismatch { detected, expected }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allowlist_parsing() {
+        assert_eq!(AllowedContentType::parse("application/wasm"), Some(AllowedContentType::Wasm));
+        assert_eq!(
+            AllowedContentType::parse("text/x-rust; charset=utf-8"),
+            Some(AllowedContentType::RustSource)
+        );
+        assert_eq!(AllowedContentType::parse("application/octet-stream"), None);
+        assert_eq!(AllowedContentType::parse("image/png"), None);
+    }
+
+    #[test]
+    fn consistent_declaration_passes() {
+        assert_eq!(
+            check("application/wasm", FileKind::Wasm),
+            ContentTypeCheck::Ok(AllowedContentType::Wasm)
+        );
+        assert_eq!(
+            check("text/x-rust", FileKind::SourceText),
+            ContentTypeCheck::Ok(AllowedContentType::RustSource)
+        );
+    }
+
+    #[test]
+    fn disallowed_type_is_rejected() {
+        assert_eq!(check("application/x-msdownload", FileKind::Wasm), ContentTypeCheck::NotAllowed);
+    }
+
+    #[test]
+    fn mismatch_is_detected() {
+        // Claims WASM but bytes are an ELF executable.
+        assert_eq!(
+            check("application/wasm", FileKind::Elf),
+            ContentTypeCheck::Mismatch {
+                detected: FileKind::Elf,
+                expected: FileKind::Wasm,
+            }
+        );
+    }
+}

--- a/src/upload_sanitization/deep_inspection.rs
+++ b/src/upload_sanitization/deep_inspection.rs
@@ -1,0 +1,230 @@
+//! Deep content inspection for embedded malicious patterns.
+//!
+//! Scans the file body for indicators that don't belong in legitimate contract
+//! code: path-traversal sequences, embedded executables, suspicious shell/eval
+//! invocations, and obfuscation signals. Each finding carries a severity so
+//! the pipeline can decide between rejecting and quarantining.
+
+use serde::{Deserialize, Serialize};
+
+/// Severity of an inspection finding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum Severity {
+    /// Worth a human's attention; quarantine.
+    Suspicious,
+    /// Almost certainly malicious; reject.
+    Malicious,
+}
+
+/// A single inspection finding.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Finding {
+    /// Short machine-readable rule id.
+    pub rule: String,
+    /// Human-readable explanation.
+    pub detail: String,
+    /// Byte offset where the pattern was found.
+    pub offset: usize,
+    /// Severity of the finding.
+    pub severity: Severity,
+}
+
+/// Aggregated inspection result.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InspectionReport {
+    /// All findings, in discovery order.
+    pub findings: Vec<Finding>,
+}
+
+impl InspectionReport {
+    /// Whether anything was flagged.
+    pub fn is_clean(&self) -> bool {
+        self.findings.is_empty()
+    }
+
+    /// Whether any finding is `Malicious`.
+    pub fn has_malicious(&self) -> bool {
+        self.findings.iter().any(|f| f.severity == Severity::Malicious)
+    }
+
+    /// The highest severity observed, if any.
+    pub fn max_severity(&self) -> Option<Severity> {
+        self.findings.iter().map(|f| f.severity).max()
+    }
+}
+
+/// A byte-pattern rule.
+struct Rule {
+    id: &'static str,
+    needle: &'static [u8],
+    detail: &'static str,
+    severity: Severity,
+}
+
+/// Patterns that should never appear in WASM or Rust contract uploads.
+const RULES: &[Rule] = &[
+    Rule {
+        id: "path-traversal",
+        needle: b"../",
+        detail: "path traversal sequence",
+        severity: Severity::Suspicious,
+    },
+    Rule {
+        id: "path-traversal-win",
+        needle: b"..\\",
+        detail: "windows path traversal sequence",
+        severity: Severity::Suspicious,
+    },
+    Rule {
+        id: "embedded-elf",
+        needle: b"\x7fELF",
+        detail: "embedded ELF executable",
+        severity: Severity::Malicious,
+    },
+    Rule {
+        id: "embedded-mz",
+        needle: b"MZ\x90\x00",
+        detail: "embedded PE/DOS executable",
+        severity: Severity::Malicious,
+    },
+    Rule {
+        id: "shell-rm-rf",
+        needle: b"rm -rf",
+        detail: "destructive shell command",
+        severity: Severity::Malicious,
+    },
+    Rule {
+        id: "reverse-shell",
+        needle: b"/dev/tcp/",
+        detail: "bash reverse-shell device",
+        severity: Severity::Malicious,
+    },
+    Rule {
+        id: "shell-eval",
+        needle: b"eval(",
+        detail: "dynamic code evaluation",
+        severity: Severity::Suspicious,
+    },
+    Rule {
+        id: "powershell-enc",
+        needle: b"powershell -enc",
+        detail: "encoded PowerShell payload",
+        severity: Severity::Malicious,
+    },
+    Rule {
+        id: "process-spawn",
+        needle: b"std::process::Command",
+        detail: "process spawning in source",
+        severity: Severity::Suspicious,
+    },
+    Rule {
+        id: "wget-pipe-sh",
+        needle: b"| sh",
+        detail: "pipe-to-shell pattern",
+        severity: Severity::Suspicious,
+    },
+];
+
+/// Inspects file bytes for malicious patterns.
+pub fn inspect(bytes: &[u8]) -> InspectionReport {
+    let mut findings = Vec::new();
+    for rule in RULES {
+        if let Some(offset) = find_subsequence(bytes, rule.needle) {
+            findings.push(Finding {
+                rule: rule.id.to_string(),
+                detail: rule.detail.to_string(),
+                offset,
+                severity: rule.severity,
+            });
+        }
+    }
+    // Obfuscation heuristic: very long lines suggest minified/packed payloads.
+    if let Some(offset) = overlong_line(bytes, 5000) {
+        findings.push(Finding {
+            rule: "overlong-line".to_string(),
+            detail: "abnormally long line (possible obfuscation/packing)".to_string(),
+            offset,
+            severity: Severity::Suspicious,
+        });
+    }
+    InspectionReport { findings }
+}
+
+/// Naive substring search returning the first match offset.
+fn find_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() || haystack.len() < needle.len() {
+        return None;
+    }
+    haystack
+        .windows(needle.len())
+        .position(|w| w == needle)
+}
+
+/// Returns the start offset of the first line longer than `max`, if any.
+fn overlong_line(bytes: &[u8], max: usize) -> Option<usize> {
+    let mut line_start = 0;
+    for (i, &b) in bytes.iter().enumerate() {
+        if b == b'\n' {
+            if i - line_start > max {
+                return Some(line_start);
+            }
+            line_start = i + 1;
+        }
+    }
+    if bytes.len() - line_start > max {
+        Some(line_start)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clean_source_has_no_findings() {
+        let src = b"pub fn add(a: i32, b: i32) -> i32 { a + b }\n";
+        let report = inspect(src);
+        assert!(report.is_clean());
+        assert!(!report.has_malicious());
+    }
+
+    #[test]
+    fn detects_path_traversal() {
+        let report = inspect(b"include_bytes!(\"../../etc/passwd\")");
+        assert!(!report.is_clean());
+        assert_eq!(report.max_severity(), Some(Severity::Suspicious));
+        assert!(report.findings.iter().any(|f| f.rule == "path-traversal"));
+    }
+
+    #[test]
+    fn detects_embedded_executable_as_malicious() {
+        let mut data = b"// harmless looking\n".to_vec();
+        data.extend_from_slice(b"\x7fELF\x02\x01");
+        let report = inspect(&data);
+        assert!(report.has_malicious());
+    }
+
+    #[test]
+    fn detects_destructive_shell() {
+        let report = inspect(b"system(\"rm -rf /\")");
+        assert!(report.has_malicious());
+        assert!(report.findings.iter().any(|f| f.rule == "shell-rm-rf"));
+    }
+
+    #[test]
+    fn detects_overlong_line() {
+        let mut data = vec![b'a'; 6000];
+        data.push(b'\n');
+        let report = inspect(&data);
+        assert!(report.findings.iter().any(|f| f.rule == "overlong-line"));
+    }
+
+    #[test]
+    fn offset_points_to_match() {
+        let report = inspect(b"abc/dev/tcp/10.0.0.1/4444");
+        let f = report.findings.iter().find(|f| f.rule == "reverse-shell").unwrap();
+        assert_eq!(f.offset, 3);
+    }
+}

--- a/src/upload_sanitization/deep_inspection.rs
+++ b/src/upload_sanitization/deep_inspection.rs
@@ -44,7 +44,9 @@ impl InspectionReport {
 
     /// Whether any finding is `Malicious`.
     pub fn has_malicious(&self) -> bool {
-        self.findings.iter().any(|f| f.severity == Severity::Malicious)
+        self.findings
+            .iter()
+            .any(|f| f.severity == Severity::Malicious)
     }
 
     /// The highest severity observed, if any.
@@ -155,9 +157,7 @@ fn find_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
     if needle.is_empty() || haystack.len() < needle.len() {
         return None;
     }
-    haystack
-        .windows(needle.len())
-        .position(|w| w == needle)
+    haystack.windows(needle.len()).position(|w| w == needle)
 }
 
 /// Returns the start offset of the first line longer than `max`, if any.
@@ -224,7 +224,11 @@ mod tests {
     #[test]
     fn offset_points_to_match() {
         let report = inspect(b"abc/dev/tcp/10.0.0.1/4444");
-        let f = report.findings.iter().find(|f| f.rule == "reverse-shell").unwrap();
+        let f = report
+            .findings
+            .iter()
+            .find(|f| f.rule == "reverse-shell")
+            .unwrap();
         assert_eq!(f.offset, 3);
     }
 }

--- a/src/upload_sanitization/limits.rs
+++ b/src/upload_sanitization/limits.rs
@@ -99,7 +99,12 @@ impl UploadRateLimiter {
     /// Checks (and on success records) an upload from `user`/`ip` at `now`.
     ///
     /// Returns `Err(scope)` for the first exceeded scope without recording.
-    pub fn check_and_record(&self, user: &str, ip: &str, now: DateTime<Utc>) -> Result<(), RateScope> {
+    pub fn check_and_record(
+        &self,
+        user: &str,
+        ip: &str,
+        now: DateTime<Utc>,
+    ) -> Result<(), RateScope> {
         let window = Duration::hours(1);
         let cutoff = now - window;
         let user_key = format!("u:{user}");
@@ -160,26 +165,50 @@ mod tests {
 
     #[test]
     fn per_user_limit_blocks() {
-        let limiter = UploadRateLimiter::new(UploadRateConfig { per_user_hourly: 3, per_ip_hourly: 100 });
+        let limiter = UploadRateLimiter::new(UploadRateConfig {
+            per_user_hourly: 3,
+            per_ip_hourly: 100,
+        });
         for _ in 0..3 {
-            assert!(limiter.check_and_record("user-1", "10.0.0.1", now()).is_ok());
+            assert!(limiter
+                .check_and_record("user-1", "10.0.0.1", now())
+                .is_ok());
         }
-        assert_eq!(limiter.check_and_record("user-1", "10.0.0.1", now()), Err(RateScope::User));
+        assert_eq!(
+            limiter.check_and_record("user-1", "10.0.0.1", now()),
+            Err(RateScope::User)
+        );
     }
 
     #[test]
     fn per_ip_limit_blocks_across_users() {
-        let limiter = UploadRateLimiter::new(UploadRateConfig { per_user_hourly: 100, per_ip_hourly: 2 });
-        assert!(limiter.check_and_record("user-a", "10.0.0.9", now()).is_ok());
-        assert!(limiter.check_and_record("user-b", "10.0.0.9", now()).is_ok());
-        assert_eq!(limiter.check_and_record("user-c", "10.0.0.9", now()), Err(RateScope::Ip));
+        let limiter = UploadRateLimiter::new(UploadRateConfig {
+            per_user_hourly: 100,
+            per_ip_hourly: 2,
+        });
+        assert!(limiter
+            .check_and_record("user-a", "10.0.0.9", now())
+            .is_ok());
+        assert!(limiter
+            .check_and_record("user-b", "10.0.0.9", now())
+            .is_ok());
+        assert_eq!(
+            limiter.check_and_record("user-c", "10.0.0.9", now()),
+            Err(RateScope::Ip)
+        );
     }
 
     #[test]
     fn window_slides() {
-        let limiter = UploadRateLimiter::new(UploadRateConfig { per_user_hourly: 1, per_ip_hourly: 100 });
+        let limiter = UploadRateLimiter::new(UploadRateConfig {
+            per_user_hourly: 1,
+            per_ip_hourly: 100,
+        });
         assert!(limiter.check_and_record("u", "1.1.1.1", now()).is_ok());
-        assert_eq!(limiter.check_and_record("u", "1.1.1.1", now()), Err(RateScope::User));
+        assert_eq!(
+            limiter.check_and_record("u", "1.1.1.1", now()),
+            Err(RateScope::User)
+        );
         let later = now() + Duration::seconds(3601);
         assert!(limiter.check_and_record("u", "1.1.1.1", later).is_ok());
     }

--- a/src/upload_sanitization/limits.rs
+++ b/src/upload_sanitization/limits.rs
@@ -1,0 +1,186 @@
+//! Tier-based size limits and per-user / per-IP upload rate limiting.
+
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+/// Account tier governing the maximum upload size.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum UploadTier {
+    /// Free tier — 1 MB.
+    Free,
+    /// Paid tier — 10 MB.
+    Paid,
+    /// Enterprise tier — 100 MB.
+    Enterprise,
+}
+
+impl UploadTier {
+    /// Maximum upload size in bytes for this tier.
+    pub fn max_bytes(&self) -> u64 {
+        match self {
+            UploadTier::Free => 1024 * 1024,
+            UploadTier::Paid => 10 * 1024 * 1024,
+            UploadTier::Enterprise => 100 * 1024 * 1024,
+        }
+    }
+
+    /// Returns `Ok(())` if `size` is within the tier limit.
+    pub fn check_size(&self, size: u64) -> Result<(), SizeError> {
+        if size == 0 {
+            return Err(SizeError::Empty);
+        }
+        let max = self.max_bytes();
+        if size > max {
+            Err(SizeError::TooLarge { size, max })
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// Why a size check failed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SizeError {
+    /// The upload had no content.
+    Empty,
+    /// The upload exceeded the tier limit.
+    TooLarge {
+        /// Actual size.
+        size: u64,
+        /// Allowed maximum.
+        max: u64,
+    },
+}
+
+/// Per-user and per-IP hourly upload-count limits.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UploadRateConfig {
+    /// Max uploads per user per hour.
+    pub per_user_hourly: u64,
+    /// Max uploads per IP per hour.
+    pub per_ip_hourly: u64,
+}
+
+impl Default for UploadRateConfig {
+    fn default() -> Self {
+        Self {
+            per_user_hourly: 20,
+            per_ip_hourly: 60,
+        }
+    }
+}
+
+/// The scope whose limit was hit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RateScope {
+    /// Per-user limit.
+    User,
+    /// Per-IP limit.
+    Ip,
+}
+
+/// A sliding-window upload rate limiter keyed by user and IP.
+pub struct UploadRateLimiter {
+    config: UploadRateConfig,
+    events: Mutex<HashMap<String, Vec<DateTime<Utc>>>>,
+}
+
+impl UploadRateLimiter {
+    /// Creates a limiter with the given configuration.
+    pub fn new(config: UploadRateConfig) -> Self {
+        Self {
+            config,
+            events: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Checks (and on success records) an upload from `user`/`ip` at `now`.
+    ///
+    /// Returns `Err(scope)` for the first exceeded scope without recording.
+    pub fn check_and_record(&self, user: &str, ip: &str, now: DateTime<Utc>) -> Result<(), RateScope> {
+        let window = Duration::hours(1);
+        let cutoff = now - window;
+        let user_key = format!("u:{user}");
+        let ip_key = format!("i:{ip}");
+
+        let mut map = self.events.lock().expect("rate limiter mutex poisoned");
+
+        let user_count = count(&map, &user_key, cutoff);
+        if user_count >= self.config.per_user_hourly {
+            return Err(RateScope::User);
+        }
+        let ip_count = count(&map, &ip_key, cutoff);
+        if ip_count >= self.config.per_ip_hourly {
+            return Err(RateScope::Ip);
+        }
+
+        map.entry(user_key).or_default().push(now);
+        map.entry(ip_key).or_default().push(now);
+        Ok(())
+    }
+}
+
+fn count(map: &HashMap<String, Vec<DateTime<Utc>>>, key: &str, cutoff: DateTime<Utc>) -> u64 {
+    map.get(key)
+        .map(|times| times.iter().filter(|t| **t > cutoff).count() as u64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn now() -> DateTime<Utc> {
+        DateTime::from_timestamp(1_700_000_000, 0).unwrap()
+    }
+
+    #[test]
+    fn tier_limits_match_acceptance_criteria() {
+        assert_eq!(UploadTier::Free.max_bytes(), 1024 * 1024);
+        assert_eq!(UploadTier::Paid.max_bytes(), 10 * 1024 * 1024);
+        assert_eq!(UploadTier::Enterprise.max_bytes(), 100 * 1024 * 1024);
+    }
+
+    #[test]
+    fn size_check_enforced() {
+        assert_eq!(UploadTier::Free.check_size(0), Err(SizeError::Empty));
+        assert!(UploadTier::Free.check_size(1024 * 1024).is_ok());
+        assert_eq!(
+            UploadTier::Free.check_size(2 * 1024 * 1024),
+            Err(SizeError::TooLarge {
+                size: 2 * 1024 * 1024,
+                max: 1024 * 1024
+            })
+        );
+        // A file too big for free fits in paid.
+        assert!(UploadTier::Paid.check_size(2 * 1024 * 1024).is_ok());
+    }
+
+    #[test]
+    fn per_user_limit_blocks() {
+        let limiter = UploadRateLimiter::new(UploadRateConfig { per_user_hourly: 3, per_ip_hourly: 100 });
+        for _ in 0..3 {
+            assert!(limiter.check_and_record("user-1", "10.0.0.1", now()).is_ok());
+        }
+        assert_eq!(limiter.check_and_record("user-1", "10.0.0.1", now()), Err(RateScope::User));
+    }
+
+    #[test]
+    fn per_ip_limit_blocks_across_users() {
+        let limiter = UploadRateLimiter::new(UploadRateConfig { per_user_hourly: 100, per_ip_hourly: 2 });
+        assert!(limiter.check_and_record("user-a", "10.0.0.9", now()).is_ok());
+        assert!(limiter.check_and_record("user-b", "10.0.0.9", now()).is_ok());
+        assert_eq!(limiter.check_and_record("user-c", "10.0.0.9", now()), Err(RateScope::Ip));
+    }
+
+    #[test]
+    fn window_slides() {
+        let limiter = UploadRateLimiter::new(UploadRateConfig { per_user_hourly: 1, per_ip_hourly: 100 });
+        assert!(limiter.check_and_record("u", "1.1.1.1", now()).is_ok());
+        assert_eq!(limiter.check_and_record("u", "1.1.1.1", now()), Err(RateScope::User));
+        let later = now() + Duration::seconds(3601);
+        assert!(limiter.check_and_record("u", "1.1.1.1", later).is_ok());
+    }
+}

--- a/src/upload_sanitization/magic.rs
+++ b/src/upload_sanitization/magic.rs
@@ -1,0 +1,165 @@
+//! Magic-number / content sniffing for uploaded files.
+//!
+//! Determines the *actual* type of a file from its bytes rather than trusting
+//! the client-declared content type or extension. This is the first line of
+//! defence against an attacker uploading an executable disguised as a `.wasm`
+//! or `.rs` file.
+
+use serde::{Deserialize, Serialize};
+
+/// The detected kind of an uploaded file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum FileKind {
+    /// WebAssembly binary (`\0asm` magic).
+    Wasm,
+    /// Plausible UTF-8 source text (e.g. Rust source / TOML manifest).
+    SourceText,
+    /// ELF executable (Linux binary) — disallowed.
+    Elf,
+    /// PE/COFF executable (`MZ`, Windows) — disallowed.
+    PeExecutable,
+    /// Mach-O executable (macOS) — disallowed.
+    MachO,
+    /// Shell script / shebang — disallowed.
+    Script,
+    /// Archive (ZIP/gzip/etc.) — disallowed (could smuggle content).
+    Archive,
+    /// Unknown / unrecognized binary content.
+    Unknown,
+}
+
+impl FileKind {
+    /// Whether this kind is ever acceptable as a contract-code upload.
+    pub fn is_uploadable(&self) -> bool {
+        matches!(self, FileKind::Wasm | FileKind::SourceText)
+    }
+
+    /// Stable label.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            FileKind::Wasm => "wasm",
+            FileKind::SourceText => "source-text",
+            FileKind::Elf => "elf-executable",
+            FileKind::PeExecutable => "pe-executable",
+            FileKind::MachO => "mach-o-executable",
+            FileKind::Script => "script",
+            FileKind::Archive => "archive",
+            FileKind::Unknown => "unknown",
+        }
+    }
+}
+
+/// The WebAssembly magic header: `\0asm` followed by a u32 version.
+pub const WASM_MAGIC: [u8; 4] = [0x00, 0x61, 0x73, 0x6d];
+
+/// Detects the file kind from a content prefix.
+pub fn detect(bytes: &[u8]) -> FileKind {
+    if bytes.starts_with(&WASM_MAGIC) {
+        return FileKind::Wasm;
+    }
+    if bytes.starts_with(b"\x7fELF") {
+        return FileKind::Elf;
+    }
+    if bytes.starts_with(b"MZ") {
+        return FileKind::PeExecutable;
+    }
+    // Mach-O (32/64-bit, both endiannesses) and universal binaries.
+    if matches!(
+        bytes.get(0..4),
+        Some([0xfe, 0xed, 0xfa, 0xce])
+            | Some([0xfe, 0xed, 0xfa, 0xcf])
+            | Some([0xcf, 0xfa, 0xed, 0xfe])
+            | Some([0xce, 0xfa, 0xed, 0xfe])
+            | Some([0xca, 0xfe, 0xba, 0xbe])
+    ) {
+        return FileKind::MachO;
+    }
+    if bytes.starts_with(b"#!") {
+        return FileKind::Script;
+    }
+    if bytes.starts_with(b"PK\x03\x04") // zip
+        || bytes.starts_with(&[0x1f, 0x8b]) // gzip
+        || bytes.starts_with(b"7z\xbc\xaf") // 7z
+        || bytes.starts_with(b"Rar!")
+    {
+        return FileKind::Archive;
+    }
+    if is_probably_text(bytes) {
+        return FileKind::SourceText;
+    }
+    FileKind::Unknown
+}
+
+/// Heuristic: a buffer is "text" if it is valid UTF-8 (over the inspected
+/// prefix) and contains no NUL bytes or excessive control characters.
+pub fn is_probably_text(bytes: &[u8]) -> bool {
+    if bytes.is_empty() {
+        return false;
+    }
+    // NUL bytes never appear in source text.
+    if bytes.contains(&0) {
+        return false;
+    }
+    // Inspect a bounded prefix for control-character density.
+    let prefix = &bytes[..bytes.len().min(8192)];
+    if std::str::from_utf8(prefix).is_err() {
+        // Allow a trailing truncated multi-byte char only on the full buffer.
+        if std::str::from_utf8(bytes).is_err() {
+            return false;
+        }
+    }
+    let control = prefix
+        .iter()
+        .filter(|b| **b < 0x09 || (**b > 0x0d && **b < 0x20))
+        .count();
+    // Fewer than ~1% control bytes.
+    control * 100 <= prefix.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_wasm() {
+        let mut wasm = WASM_MAGIC.to_vec();
+        wasm.extend_from_slice(&[0x01, 0x00, 0x00, 0x00]); // version 1
+        assert_eq!(detect(&wasm), FileKind::Wasm);
+        assert!(detect(&wasm).is_uploadable());
+    }
+
+    #[test]
+    fn detects_rust_source() {
+        let src = b"pub fn main() {\n    println!(\"hi\");\n}\n";
+        assert_eq!(detect(src), FileKind::SourceText);
+        assert!(detect(src).is_uploadable());
+    }
+
+    #[test]
+    fn detects_executables() {
+        assert_eq!(detect(b"\x7fELF\x02\x01\x01\x00"), FileKind::Elf);
+        assert_eq!(detect(b"MZ\x90\x00"), FileKind::PeExecutable);
+        assert_eq!(detect(&[0xfe, 0xed, 0xfa, 0xcf, 0, 0]), FileKind::MachO);
+        for kind in [FileKind::Elf, FileKind::PeExecutable, FileKind::MachO] {
+            assert!(!kind.is_uploadable());
+        }
+    }
+
+    #[test]
+    fn detects_scripts_and_archives() {
+        assert_eq!(detect(b"#!/bin/bash\nrm -rf /\n"), FileKind::Script);
+        assert_eq!(detect(b"PK\x03\x04rest"), FileKind::Archive);
+        assert_eq!(detect(&[0x1f, 0x8b, 0x08]), FileKind::Archive);
+    }
+
+    #[test]
+    fn binary_with_nul_is_not_text() {
+        assert!(!is_probably_text(b"abc\0def"));
+        assert_eq!(detect(b"abc\0\0\0\xff\xfe"), FileKind::Unknown);
+    }
+
+    #[test]
+    fn empty_is_unknown() {
+        assert_eq!(detect(b""), FileKind::Unknown);
+    }
+}

--- a/src/upload_sanitization/malware.rs
+++ b/src/upload_sanitization/malware.rs
@@ -1,0 +1,131 @@
+//! Malware / virus scanning integration.
+//!
+//! Defines a [`MalwareScanner`] trait so a production deployment can wire in
+//! ClamAV, an AV vendor API, or a sandbox detonation service. A built-in
+//! [`SignatureScanner`] provides a dependency-free default that matches known
+//! byte signatures, including the standard EICAR antivirus test string.
+
+use serde::{Deserialize, Serialize};
+
+/// Verdict from a malware scan.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ScanVerdict {
+    /// No threats found.
+    Clean,
+    /// A known threat was identified.
+    Infected {
+        /// Name/id of the matched signature.
+        signature: String,
+    },
+    /// The scanner could not reach a conclusion (treat as suspicious).
+    Indeterminate {
+        /// Why the scan was inconclusive.
+        reason: String,
+    },
+}
+
+impl ScanVerdict {
+    /// Whether the verdict permits the upload to proceed without quarantine.
+    pub fn is_clean(&self) -> bool {
+        matches!(self, ScanVerdict::Clean)
+    }
+}
+
+/// A pluggable malware scanner. Implementations must be thread-safe.
+pub trait MalwareScanner: Send + Sync {
+    /// Scans the file bytes and returns a verdict.
+    fn scan(&self, bytes: &[u8]) -> ScanVerdict;
+}
+
+/// The EICAR standard antivirus test file content. Any real scanner flags it;
+/// the default scanner recognises it so the integration can be tested safely.
+pub const EICAR_TEST: &[u8] =
+    br#"X5O!P%@AP[4\PZX54(P^)7CC)7}$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!$H+H*"#;
+
+/// A signature-based scanner matching known-bad byte sequences.
+#[derive(Clone)]
+pub struct SignatureScanner {
+    signatures: Vec<(String, Vec<u8>)>,
+}
+
+impl Default for SignatureScanner {
+    fn default() -> Self {
+        Self {
+            signatures: vec![("EICAR-Test-File".to_string(), EICAR_TEST.to_vec())],
+        }
+    }
+}
+
+impl SignatureScanner {
+    /// Creates a scanner seeded with the default signatures (EICAR).
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Adds a custom named signature.
+    pub fn with_signature(mut self, name: impl Into<String>, bytes: impl Into<Vec<u8>>) -> Self {
+        self.signatures.push((name.into(), bytes.into()));
+        self
+    }
+}
+
+impl MalwareScanner for SignatureScanner {
+    fn scan(&self, bytes: &[u8]) -> ScanVerdict {
+        for (name, sig) in &self.signatures {
+            if !sig.is_empty() && contains(bytes, sig) {
+                return ScanVerdict::Infected {
+                    signature: name.clone(),
+                };
+            }
+        }
+        ScanVerdict::Clean
+    }
+}
+
+fn contains(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack.len() >= needle.len() && haystack.windows(needle.len()).any(|w| w == needle)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clean_file_passes() {
+        let scanner = SignatureScanner::new();
+        assert_eq!(scanner.scan(b"pub fn main() {}"), ScanVerdict::Clean);
+    }
+
+    #[test]
+    fn eicar_is_detected() {
+        let scanner = SignatureScanner::new();
+        match scanner.scan(EICAR_TEST) {
+            ScanVerdict::Infected { signature } => assert_eq!(signature, "EICAR-Test-File"),
+            other => panic!("expected infected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn eicar_detected_when_embedded() {
+        let scanner = SignatureScanner::new();
+        let mut data = b"prefix ".to_vec();
+        data.extend_from_slice(EICAR_TEST);
+        data.extend_from_slice(b" suffix");
+        assert!(!scanner.scan(&data).is_clean());
+    }
+
+    #[test]
+    fn custom_signature_matches() {
+        let scanner = SignatureScanner::new().with_signature("Demo", b"BADWARE".to_vec());
+        assert_eq!(
+            scanner.scan(b"...BADWARE..."),
+            ScanVerdict::Infected { signature: "Demo".to_string() }
+        );
+    }
+
+    #[test]
+    fn verdict_clean_predicate() {
+        assert!(ScanVerdict::Clean.is_clean());
+        assert!(!ScanVerdict::Indeterminate { reason: "timeout".into() }.is_clean());
+    }
+}

--- a/src/upload_sanitization/malware.rs
+++ b/src/upload_sanitization/malware.rs
@@ -119,13 +119,18 @@ mod tests {
         let scanner = SignatureScanner::new().with_signature("Demo", b"BADWARE".to_vec());
         assert_eq!(
             scanner.scan(b"...BADWARE..."),
-            ScanVerdict::Infected { signature: "Demo".to_string() }
+            ScanVerdict::Infected {
+                signature: "Demo".to_string(),
+            }
         );
     }
 
     #[test]
     fn verdict_clean_predicate() {
         assert!(ScanVerdict::Clean.is_clean());
-        assert!(!ScanVerdict::Indeterminate { reason: "timeout".into() }.is_clean());
+        let verdict = ScanVerdict::Indeterminate {
+            reason: "timeout".into(),
+        };
+        assert!(!verdict.is_clean());
     }
 }

--- a/src/upload_sanitization/mod.rs
+++ b/src/upload_sanitization/mod.rs
@@ -1,0 +1,67 @@
+//! Input sanitization and validation for contract-code uploads (issue #330).
+//!
+//! A defence-in-depth pipeline that validates an uploaded file before it ever
+//! reaches the parser/analyzer. It sniffs the true file type from magic bytes,
+//! enforces a content-type allowlist, structurally validates WASM, scans for
+//! embedded malicious patterns and known malware, sanitizes accepted content,
+//! and quarantines anything suspicious — all under tier-based size limits and
+//! per-user / per-IP rate limiting.
+//!
+//! # Acceptance-criteria mapping
+//!
+//! | Requirement | Where |
+//! |-------------|-------|
+//! | File-type validation via magic numbers | [`magic::detect`] |
+//! | Content-type allowlist (WASM, Rust, …) | [`content_type`] |
+//! | Deep inspection for malicious patterns | [`deep_inspection::inspect`] |
+//! | WASM structure validation (header/sections) | [`wasm::validate`] |
+//! | Virus/malware scanning integration | [`malware::MalwareScanner`] |
+//! | Content sanitization | [`sanitize::sanitize_content`] |
+//! | Quarantine system for suspicious files | [`quarantine::Quarantine`] |
+//! | Upload rate limiting (per user / per IP) | [`limits::UploadRateLimiter`] |
+//! | Tier-based size limits (1/10/100 MB) | [`limits::UploadTier`] |
+//! | Progress tracking & timeout handling | [`progress::UploadProgress`] |
+//! | Comprehensive security testing | per-module tests + [`tests`] |
+//!
+//! # Example
+//!
+//! ```
+//! use soroban_security_scanner::upload_sanitization::*;
+//!
+//! let scanner = SignatureScanner::new();
+//! let req = UploadRequest {
+//!     bytes: b"pub fn main() {}\n",
+//!     declared_content_type: "text/x-rust",
+//!     filename: "../../etc/lib.rs",
+//!     tier: UploadTier::Free,
+//! };
+//! match validate_upload(&req, &scanner) {
+//!     UploadVerdict::Accepted { filename, .. } => assert_eq!(filename, "lib.rs"),
+//!     other => panic!("unexpected: {other:?}"),
+//! }
+//! ```
+
+pub mod content_type;
+pub mod deep_inspection;
+pub mod limits;
+pub mod magic;
+pub mod malware;
+pub mod pipeline;
+pub mod progress;
+pub mod quarantine;
+pub mod sanitize;
+pub mod wasm;
+
+#[cfg(test)]
+mod tests;
+
+pub use content_type::{check as check_content_type, AllowedContentType, ContentTypeCheck};
+pub use deep_inspection::{inspect, Finding, InspectionReport, Severity};
+pub use limits::{RateScope, SizeError, UploadRateConfig, UploadRateLimiter, UploadTier};
+pub use magic::{detect, FileKind};
+pub use malware::{MalwareScanner, ScanVerdict, SignatureScanner};
+pub use pipeline::{validate_upload, UploadRequest, UploadVerdict};
+pub use progress::{UploadProgress, UploadState};
+pub use quarantine::{Quarantine, QuarantineEntry, QuarantineStatus};
+pub use sanitize::{sanitize_content, sanitize_filename, Sanitized};
+pub use wasm::{validate as validate_wasm, WasmError, WasmInfo};

--- a/src/upload_sanitization/pipeline.rs
+++ b/src/upload_sanitization/pipeline.rs
@@ -98,7 +98,10 @@ pub fn validate_upload(req: &UploadRequest, scanner: &dyn MalwareScanner) -> Upl
         ContentTypeCheck::NotAllowed => {
             return UploadVerdict::reject(
                 "content-type",
-                format!("content type '{}' is not allowed", req.declared_content_type),
+                format!(
+                    "content type '{}' is not allowed",
+                    req.declared_content_type
+                ),
             )
         }
         ContentTypeCheck::Mismatch { detected, expected } => {

--- a/src/upload_sanitization/pipeline.rs
+++ b/src/upload_sanitization/pipeline.rs
@@ -1,0 +1,328 @@
+//! The end-to-end upload validation pipeline.
+//!
+//! Runs every stage in order and produces a single [`UploadVerdict`]:
+//! size → magic sniff → content-type consistency → WASM structure →
+//! deep inspection → malware scan → sanitize. The first hard failure rejects;
+//! suspicious-but-not-malicious findings route to quarantine; otherwise the
+//! sanitized bytes are accepted.
+
+use crate::upload_sanitization::content_type::{check as check_content_type, ContentTypeCheck};
+use crate::upload_sanitization::deep_inspection::{inspect, Severity};
+use crate::upload_sanitization::limits::{SizeError, UploadTier};
+use crate::upload_sanitization::magic::{detect, FileKind};
+use crate::upload_sanitization::malware::{MalwareScanner, ScanVerdict};
+use crate::upload_sanitization::sanitize::{sanitize_content, sanitize_filename};
+use crate::upload_sanitization::wasm::validate as validate_wasm;
+use serde::{Deserialize, Serialize};
+
+/// Inputs describing one upload to validate.
+#[derive(Debug, Clone)]
+pub struct UploadRequest<'a> {
+    /// Raw file bytes.
+    pub bytes: &'a [u8],
+    /// Client-declared MIME type.
+    pub declared_content_type: &'a str,
+    /// Client-supplied filename (untrusted).
+    pub filename: &'a str,
+    /// Uploader's tier (governs size limit).
+    pub tier: UploadTier,
+}
+
+/// The terminal decision for an upload.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum UploadVerdict {
+    /// Accepted; carries the sanitized bytes and a safe filename.
+    Accepted {
+        /// Cleaned file bytes.
+        sanitized_bytes: Vec<u8>,
+        /// Sanitized filename.
+        filename: String,
+        /// Detected kind.
+        kind: FileKind,
+    },
+    /// Held for manual review.
+    Quarantined {
+        /// Why it was quarantined.
+        reason: String,
+        /// Safe filename for the quarantine record.
+        filename: String,
+    },
+    /// Rejected outright.
+    Rejected {
+        /// Machine-readable stage/cause.
+        stage: String,
+        /// Human-readable reason.
+        reason: String,
+    },
+}
+
+impl UploadVerdict {
+    /// Whether the upload was accepted.
+    pub fn is_accepted(&self) -> bool {
+        matches!(self, UploadVerdict::Accepted { .. })
+    }
+
+    fn reject(stage: &str, reason: impl Into<String>) -> Self {
+        UploadVerdict::Rejected {
+            stage: stage.to_string(),
+            reason: reason.into(),
+        }
+    }
+}
+
+/// Validates an upload through the full pipeline.
+pub fn validate_upload(req: &UploadRequest, scanner: &dyn MalwareScanner) -> UploadVerdict {
+    let safe_name = sanitize_filename(req.filename);
+
+    // 1. Size / tier limit.
+    match req.tier.check_size(req.bytes.len() as u64) {
+        Ok(()) => {}
+        Err(SizeError::Empty) => return UploadVerdict::reject("size", "upload is empty"),
+        Err(SizeError::TooLarge { size, max }) => {
+            return UploadVerdict::reject(
+                "size",
+                format!("{size} bytes exceeds tier limit of {max} bytes"),
+            )
+        }
+    }
+
+    // 2. Magic-number sniff.
+    let kind = detect(req.bytes);
+    if !kind.is_uploadable() {
+        return UploadVerdict::reject("magic", format!("disallowed file kind: {}", kind.as_str()));
+    }
+
+    // 3. Declared content-type must be allowlisted and consistent.
+    match check_content_type(req.declared_content_type, kind) {
+        ContentTypeCheck::Ok(_) => {}
+        ContentTypeCheck::NotAllowed => {
+            return UploadVerdict::reject(
+                "content-type",
+                format!("content type '{}' is not allowed", req.declared_content_type),
+            )
+        }
+        ContentTypeCheck::Mismatch { detected, expected } => {
+            return UploadVerdict::reject(
+                "content-type",
+                format!(
+                    "declared type implies {} but content is {}",
+                    expected.as_str(),
+                    detected.as_str()
+                ),
+            )
+        }
+    }
+
+    // 4. WASM structural validation.
+    if kind == FileKind::Wasm {
+        if let Err(e) = validate_wasm(req.bytes) {
+            return UploadVerdict::reject("wasm-structure", format!("malformed WASM: {e:?}"));
+        }
+    }
+
+    // 5. Deep inspection.
+    let report = inspect(req.bytes);
+    if report.has_malicious() {
+        let rules: Vec<_> = report.findings.iter().map(|f| f.rule.as_str()).collect();
+        return UploadVerdict::reject(
+            "deep-inspection",
+            format!("malicious pattern(s): {}", rules.join(", ")),
+        );
+    }
+
+    // 6. Malware scan.
+    match scanner.scan(req.bytes) {
+        ScanVerdict::Clean => {}
+        ScanVerdict::Infected { signature } => {
+            return UploadVerdict::reject("malware", format!("infected: {signature}"))
+        }
+        ScanVerdict::Indeterminate { reason } => {
+            return UploadVerdict::Quarantined {
+                reason: format!("malware scan inconclusive: {reason}"),
+                filename: safe_name,
+            }
+        }
+    }
+
+    // 7. Suspicious (non-malicious) findings → quarantine.
+    if report.max_severity() == Some(Severity::Suspicious) {
+        let rules: Vec<_> = report.findings.iter().map(|f| f.rule.as_str()).collect();
+        return UploadVerdict::Quarantined {
+            reason: format!("suspicious pattern(s): {}", rules.join(", ")),
+            filename: safe_name,
+        };
+    }
+
+    // 8. Accept with sanitized content.
+    let sanitized = sanitize_content(req.bytes, kind);
+    UploadVerdict::Accepted {
+        sanitized_bytes: sanitized.bytes,
+        filename: safe_name,
+        kind,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::upload_sanitization::malware::SignatureScanner;
+    use crate::upload_sanitization::wasm::SUPPORTED_VERSION;
+
+    fn scanner() -> SignatureScanner {
+        SignatureScanner::new()
+    }
+
+    fn valid_wasm() -> Vec<u8> {
+        let mut m = vec![0x00, 0x61, 0x73, 0x6d];
+        m.extend_from_slice(&SUPPORTED_VERSION.to_le_bytes());
+        m.push(1); // type section
+        m.push(1); // length 1
+        m.push(0); // payload
+        m
+    }
+
+    #[test]
+    fn accepts_clean_rust_source() {
+        let req = UploadRequest {
+            bytes: b"pub fn main() {}\n",
+            declared_content_type: "text/x-rust",
+            filename: "lib.rs",
+            tier: UploadTier::Free,
+        };
+        let verdict = validate_upload(&req, &scanner());
+        assert!(verdict.is_accepted());
+    }
+
+    #[test]
+    fn accepts_valid_wasm() {
+        let wasm = valid_wasm();
+        let req = UploadRequest {
+            bytes: &wasm,
+            declared_content_type: "application/wasm",
+            filename: "contract.wasm",
+            tier: UploadTier::Free,
+        };
+        assert!(validate_upload(&req, &scanner()).is_accepted());
+    }
+
+    #[test]
+    fn rejects_oversized_for_tier() {
+        let big = vec![b'a'; 2 * 1024 * 1024];
+        let req = UploadRequest {
+            bytes: &big,
+            declared_content_type: "text/plain",
+            filename: "big.rs",
+            tier: UploadTier::Free,
+        };
+        match validate_upload(&req, &scanner()) {
+            UploadVerdict::Rejected { stage, .. } => assert_eq!(stage, "size"),
+            other => panic!("expected size rejection, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_disguised_executable() {
+        // ELF bytes declared as wasm.
+        let req = UploadRequest {
+            bytes: b"\x7fELF\x02\x01\x01\x00rest of binary",
+            declared_content_type: "application/wasm",
+            filename: "contract.wasm",
+            tier: UploadTier::Free,
+        };
+        match validate_upload(&req, &scanner()) {
+            UploadVerdict::Rejected { stage, .. } => assert_eq!(stage, "magic"),
+            other => panic!("expected magic rejection, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_content_type_mismatch() {
+        // Real Rust source but declared as wasm.
+        let req = UploadRequest {
+            bytes: b"pub fn main() {}\n",
+            declared_content_type: "application/wasm",
+            filename: "lib.rs",
+            tier: UploadTier::Free,
+        };
+        match validate_upload(&req, &scanner()) {
+            UploadVerdict::Rejected { stage, .. } => assert_eq!(stage, "content-type"),
+            other => panic!("expected content-type rejection, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_malformed_wasm() {
+        let mut wasm = vec![0x00, 0x61, 0x73, 0x6d];
+        wasm.extend_from_slice(&SUPPORTED_VERSION.to_le_bytes());
+        wasm.push(1); // section id
+        wasm.push(200); // claims 200 bytes that aren't there
+        let req = UploadRequest {
+            bytes: &wasm,
+            declared_content_type: "application/wasm",
+            filename: "contract.wasm",
+            tier: UploadTier::Free,
+        };
+        match validate_upload(&req, &scanner()) {
+            UploadVerdict::Rejected { stage, .. } => assert_eq!(stage, "wasm-structure"),
+            other => panic!("expected wasm-structure rejection, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_malicious_pattern() {
+        let req = UploadRequest {
+            bytes: b"fn x() { /* rm -rf / */ }",
+            declared_content_type: "text/x-rust",
+            filename: "evil.rs",
+            tier: UploadTier::Free,
+        };
+        match validate_upload(&req, &scanner()) {
+            UploadVerdict::Rejected { stage, .. } => assert_eq!(stage, "deep-inspection"),
+            other => panic!("expected deep-inspection rejection, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn quarantines_suspicious_pattern() {
+        let req = UploadRequest {
+            bytes: b"let p = include_str!(\"../../secret.toml\");",
+            declared_content_type: "text/x-rust",
+            filename: "sneaky.rs",
+            tier: UploadTier::Free,
+        };
+        match validate_upload(&req, &scanner()) {
+            UploadVerdict::Quarantined { .. } => {}
+            other => panic!("expected quarantine, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn detects_eicar_via_scanner() {
+        use crate::upload_sanitization::malware::EICAR_TEST;
+        let req = UploadRequest {
+            bytes: EICAR_TEST,
+            declared_content_type: "text/plain",
+            filename: "test.txt",
+            tier: UploadTier::Free,
+        };
+        match validate_upload(&req, &scanner()) {
+            UploadVerdict::Rejected { stage, .. } => assert_eq!(stage, "malware"),
+            other => panic!("expected malware rejection, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn accepted_filename_is_sanitized() {
+        let req = UploadRequest {
+            bytes: b"pub fn main() {}\n",
+            declared_content_type: "text/x-rust",
+            filename: "../../etc/lib.rs",
+            tier: UploadTier::Free,
+        };
+        if let UploadVerdict::Accepted { filename, .. } = validate_upload(&req, &scanner()) {
+            assert_eq!(filename, "lib.rs");
+        } else {
+            panic!("expected acceptance");
+        }
+    }
+}

--- a/src/upload_sanitization/progress.rs
+++ b/src/upload_sanitization/progress.rs
@@ -1,0 +1,133 @@
+//! Upload progress tracking and timeout handling.
+//!
+//! Tracks a streaming upload's byte progress against an expected total, detects
+//! stalls/timeouts based on the last-activity time, and refuses to accept more
+//! bytes than declared (a guard against length-mismatch smuggling).
+
+use serde::{Deserialize, Serialize};
+
+/// State of an in-flight upload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum UploadState {
+    /// Still receiving data.
+    InProgress,
+    /// All declared bytes received.
+    Complete,
+    /// Timed out due to inactivity.
+    TimedOut,
+    /// Aborted (e.g. declared size exceeded or cancelled).
+    Aborted,
+}
+
+/// Tracks a single upload's progress.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UploadProgress {
+    /// Total bytes the client declared it will send.
+    pub total_bytes: u64,
+    /// Bytes received so far.
+    pub received_bytes: u64,
+    /// Unix timestamp (secs) of the last received chunk.
+    pub last_activity: i64,
+    /// Inactivity timeout in seconds.
+    pub timeout_secs: i64,
+    /// Current state.
+    pub state: UploadState,
+}
+
+impl UploadProgress {
+    /// Starts tracking an upload of `total_bytes`, beginning at `now`.
+    pub fn start(total_bytes: u64, now: i64, timeout_secs: i64) -> Self {
+        Self {
+            total_bytes,
+            received_bytes: 0,
+            last_activity: now,
+            timeout_secs,
+            state: UploadState::InProgress,
+        }
+    }
+
+    /// Fraction complete in `[0.0, 1.0]`.
+    pub fn fraction(&self) -> f64 {
+        if self.total_bytes == 0 {
+            return 1.0;
+        }
+        (self.received_bytes as f64 / self.total_bytes as f64).min(1.0)
+    }
+
+    /// Records a received chunk at `now`. Returns the resulting state.
+    ///
+    /// Receiving more than `total_bytes` aborts the upload — a declared/actual
+    /// length mismatch is treated as hostile.
+    pub fn record_chunk(&mut self, len: u64, now: i64) -> UploadState {
+        if self.state != UploadState::InProgress {
+            return self.state;
+        }
+        // Enforce timeout based on the gap since last activity.
+        if now - self.last_activity > self.timeout_secs {
+            self.state = UploadState::TimedOut;
+            return self.state;
+        }
+        self.received_bytes = self.received_bytes.saturating_add(len);
+        self.last_activity = now;
+        if self.received_bytes > self.total_bytes {
+            self.state = UploadState::Aborted;
+        } else if self.received_bytes == self.total_bytes {
+            self.state = UploadState::Complete;
+        }
+        self.state
+    }
+
+    /// Re-evaluates the timeout without new data (e.g. on a watchdog tick).
+    pub fn poll_timeout(&mut self, now: i64) -> UploadState {
+        if self.state == UploadState::InProgress && now - self.last_activity > self.timeout_secs {
+            self.state = UploadState::TimedOut;
+        }
+        self.state
+    }
+
+    /// Whether the upload completed successfully.
+    pub fn is_complete(&self) -> bool {
+        self.state == UploadState::Complete
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn completes_when_all_bytes_received() {
+        let mut p = UploadProgress::start(100, 1000, 30);
+        assert_eq!(p.record_chunk(60, 1001), UploadState::InProgress);
+        assert!((p.fraction() - 0.6).abs() < 1e-9);
+        assert_eq!(p.record_chunk(40, 1002), UploadState::Complete);
+        assert!(p.is_complete());
+    }
+
+    #[test]
+    fn aborts_on_size_overrun() {
+        let mut p = UploadProgress::start(100, 1000, 30);
+        assert_eq!(p.record_chunk(150, 1001), UploadState::Aborted);
+    }
+
+    #[test]
+    fn times_out_on_inactivity() {
+        let mut p = UploadProgress::start(100, 1000, 30);
+        p.record_chunk(10, 1005);
+        // Next chunk arrives after the timeout window.
+        assert_eq!(p.record_chunk(10, 1100), UploadState::TimedOut);
+    }
+
+    #[test]
+    fn poll_detects_stall() {
+        let mut p = UploadProgress::start(100, 1000, 30);
+        assert_eq!(p.poll_timeout(1010), UploadState::InProgress);
+        assert_eq!(p.poll_timeout(1040), UploadState::TimedOut);
+    }
+
+    #[test]
+    fn zero_length_upload_is_fully_fractioned() {
+        let p = UploadProgress::start(0, 1000, 30);
+        assert_eq!(p.fraction(), 1.0);
+    }
+}

--- a/src/upload_sanitization/quarantine.rs
+++ b/src/upload_sanitization/quarantine.rs
@@ -1,0 +1,185 @@
+//! Quarantine store for suspicious uploads awaiting manual review.
+//!
+//! When a file is flagged as suspicious (but not outright malicious) it is
+//! quarantined rather than accepted or destroyed: the bytes are held, indexed
+//! by a content hash, and an admin can later release or purge them. Confirmed
+//! malicious files are also quarantined for forensic review.
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use uuid::Uuid;
+
+/// Disposition of a quarantined item.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum QuarantineStatus {
+    /// Awaiting an admin decision.
+    PendingReview,
+    /// Cleared by a reviewer.
+    Released,
+    /// Confirmed bad and purged.
+    Purged,
+}
+
+/// A quarantined file record.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QuarantineEntry {
+    /// Unique id.
+    pub id: Uuid,
+    /// SHA-256 of the content (also a dedupe key).
+    pub sha256: String,
+    /// Sanitized original filename.
+    pub filename: String,
+    /// Who uploaded it.
+    pub uploader: Uuid,
+    /// Why it was quarantined.
+    pub reason: String,
+    /// When it was quarantined (unix secs).
+    pub created_at: i64,
+    /// Current status.
+    pub status: QuarantineStatus,
+    /// The held bytes (omitted once purged).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bytes: Option<Vec<u8>>,
+}
+
+/// In-memory quarantine store.
+#[derive(Default)]
+pub struct Quarantine {
+    entries: HashMap<Uuid, QuarantineEntry>,
+}
+
+impl Quarantine {
+    /// Creates an empty quarantine.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Quarantines a file, returning its new entry id.
+    pub fn add(
+        &mut self,
+        bytes: &[u8],
+        filename: impl Into<String>,
+        uploader: Uuid,
+        reason: impl Into<String>,
+        now: i64,
+    ) -> Uuid {
+        let id = Uuid::new_v4();
+        let entry = QuarantineEntry {
+            id,
+            sha256: sha256_hex(bytes),
+            filename: filename.into(),
+            uploader,
+            reason: reason.into(),
+            created_at: now,
+            status: QuarantineStatus::PendingReview,
+            bytes: Some(bytes.to_vec()),
+        };
+        self.entries.insert(id, entry);
+        id
+    }
+
+    /// Fetches an entry.
+    pub fn get(&self, id: Uuid) -> Option<&QuarantineEntry> {
+        self.entries.get(&id)
+    }
+
+    /// All entries awaiting review.
+    pub fn pending(&self) -> Vec<&QuarantineEntry> {
+        self.entries
+            .values()
+            .filter(|e| e.status == QuarantineStatus::PendingReview)
+            .collect()
+    }
+
+    /// Releases an entry as a false positive; returns the held bytes.
+    pub fn release(&mut self, id: Uuid) -> Option<Vec<u8>> {
+        let entry = self.entries.get_mut(&id)?;
+        if entry.status != QuarantineStatus::PendingReview {
+            return None;
+        }
+        entry.status = QuarantineStatus::Released;
+        entry.bytes.clone()
+    }
+
+    /// Purges an entry's bytes after confirming it is malicious.
+    pub fn purge(&mut self, id: Uuid) -> bool {
+        if let Some(entry) = self.entries.get_mut(&id) {
+            entry.status = QuarantineStatus::Purged;
+            entry.bytes = None;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Number of entries currently pending review.
+    pub fn pending_count(&self) -> usize {
+        self.pending().len()
+    }
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hex::encode(hasher.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_and_fetch() {
+        let mut q = Quarantine::new();
+        let uploader = Uuid::new_v4();
+        let id = q.add(b"suspicious", "x.rs", uploader, "overlong line", 1000);
+        let entry = q.get(id).unwrap();
+        assert_eq!(entry.status, QuarantineStatus::PendingReview);
+        assert_eq!(entry.uploader, uploader);
+        assert!(entry.bytes.is_some());
+        assert_eq!(q.pending_count(), 1);
+    }
+
+    #[test]
+    fn release_returns_bytes_and_clears_pending() {
+        let mut q = Quarantine::new();
+        let id = q.add(b"data", "x.rs", Uuid::new_v4(), "review", 1000);
+        let released = q.release(id).unwrap();
+        assert_eq!(released, b"data");
+        assert_eq!(q.get(id).unwrap().status, QuarantineStatus::Released);
+        assert_eq!(q.pending_count(), 0);
+        // Cannot release twice.
+        assert!(q.release(id).is_none());
+    }
+
+    #[test]
+    fn purge_drops_bytes() {
+        let mut q = Quarantine::new();
+        let id = q.add(b"malware", "x.rs", Uuid::new_v4(), "eicar", 1000);
+        assert!(q.purge(id));
+        let entry = q.get(id).unwrap();
+        assert_eq!(entry.status, QuarantineStatus::Purged);
+        assert!(entry.bytes.is_none());
+    }
+
+    #[test]
+    fn hash_is_recorded() {
+        let mut q = Quarantine::new();
+        let id = q.add(b"abc", "x.rs", Uuid::new_v4(), "r", 1000);
+        // SHA-256("abc")
+        assert_eq!(
+            q.get(id).unwrap().sha256,
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    #[test]
+    fn purged_entry_omits_bytes_in_json() {
+        let mut q = Quarantine::new();
+        let id = q.add(b"malware", "x.rs", Uuid::new_v4(), "eicar", 1000);
+        q.purge(id);
+        let json = serde_json::to_string(q.get(id).unwrap()).unwrap();
+        assert!(!json.contains("bytes"));
+    }
+}

--- a/src/upload_sanitization/sanitize.rs
+++ b/src/upload_sanitization/sanitize.rs
@@ -1,0 +1,146 @@
+//! Content sanitization.
+//!
+//! Normalizes accepted uploads by stripping elements that are dangerous or
+//! useless to the scanner: UTF-8 BOMs, NUL and most control bytes, and a
+//! sanitized filename free of path components and traversal sequences. WASM
+//! binaries are passed through untouched (their bytes are validated
+//! structurally elsewhere); only text uploads are rewritten.
+
+use crate::upload_sanitization::magic::FileKind;
+use serde::{Deserialize, Serialize};
+
+/// Outcome of sanitizing an upload.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Sanitized {
+    /// The cleaned bytes.
+    pub bytes: Vec<u8>,
+    /// Whether any modification was made.
+    pub modified: bool,
+    /// Notes describing what was changed.
+    pub notes: Vec<String>,
+}
+
+/// Sanitizes file content according to its detected kind.
+pub fn sanitize_content(bytes: &[u8], kind: FileKind) -> Sanitized {
+    match kind {
+        // Binary WASM is validated structurally; do not mutate its bytes.
+        FileKind::Wasm => Sanitized {
+            bytes: bytes.to_vec(),
+            modified: false,
+            notes: vec![],
+        },
+        _ => sanitize_text(bytes),
+    }
+}
+
+fn sanitize_text(bytes: &[u8]) -> Sanitized {
+    let mut notes = Vec::new();
+    let mut out = bytes.to_vec();
+
+    // Strip a UTF-8 BOM.
+    if out.starts_with(&[0xEF, 0xBB, 0xBF]) {
+        out.drain(0..3);
+        notes.push("removed UTF-8 BOM".to_string());
+    }
+
+    // Remove NUL and control bytes except tab (0x09), LF (0x0a), CR (0x0d).
+    let before = out.len();
+    out.retain(|b| *b >= 0x20 || *b == 0x09 || *b == 0x0a || *b == 0x0d);
+    if out.len() != before {
+        notes.push(format!("removed {} control byte(s)", before - out.len()));
+    }
+
+    // Normalize CRLF / lone CR to LF.
+    if out.contains(&b'\r') {
+        out = normalize_newlines(&out);
+        notes.push("normalized line endings to LF".to_string());
+    }
+
+    let modified = !notes.is_empty();
+    Sanitized { bytes: out, modified, notes }
+}
+
+fn normalize_newlines(bytes: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\r' => {
+                out.push(b'\n');
+                // Skip a following LF (CRLF → single LF).
+                if bytes.get(i + 1) == Some(&b'\n') {
+                    i += 1;
+                }
+            }
+            other => out.push(other),
+        }
+        i += 1;
+    }
+    out
+}
+
+/// Sanitizes a client-supplied filename: strips any directory components and
+/// traversal sequences, keeping only a safe base name. Returns a fallback when
+/// nothing safe remains.
+pub fn sanitize_filename(name: &str) -> String {
+    // Take the last path component under either separator.
+    let base = name
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or("")
+        .replace("..", "");
+    let cleaned: String = base
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_'))
+        .collect();
+    let trimmed = cleaned.trim_matches('.').to_string();
+    if trimmed.is_empty() {
+        "upload.bin".to_string()
+    } else {
+        trimmed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wasm_is_untouched() {
+        let wasm = vec![0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00];
+        let s = sanitize_content(&wasm, FileKind::Wasm);
+        assert!(!s.modified);
+        assert_eq!(s.bytes, wasm);
+    }
+
+    #[test]
+    fn strips_bom_and_control_bytes() {
+        let mut data = vec![0xEF, 0xBB, 0xBF];
+        data.extend_from_slice(b"fn main() {}\x00\x07");
+        let s = sanitize_content(&data, FileKind::SourceText);
+        assert!(s.modified);
+        assert!(!s.bytes.contains(&0));
+        assert!(s.bytes.starts_with(b"fn main"));
+    }
+
+    #[test]
+    fn normalizes_newlines() {
+        let s = sanitize_content(b"a\r\nb\rc", FileKind::SourceText);
+        assert_eq!(s.bytes, b"a\nb\nc");
+        assert!(s.notes.iter().any(|n| n.contains("line endings")));
+    }
+
+    #[test]
+    fn clean_text_is_unmodified() {
+        let s = sanitize_content(b"fn main() {}\n", FileKind::SourceText);
+        assert!(!s.modified);
+    }
+
+    #[test]
+    fn filename_strips_paths_and_traversal() {
+        assert_eq!(sanitize_filename("../../etc/passwd"), "passwd");
+        assert_eq!(sanitize_filename("..\\..\\windows\\system32\\cmd.exe"), "cmd.exe");
+        assert_eq!(sanitize_filename("contract.wasm"), "contract.wasm");
+        assert_eq!(sanitize_filename("..."), "upload.bin");
+    }
+}

--- a/src/upload_sanitization/sanitize.rs
+++ b/src/upload_sanitization/sanitize.rs
@@ -57,7 +57,11 @@ fn sanitize_text(bytes: &[u8]) -> Sanitized {
     }
 
     let modified = !notes.is_empty();
-    Sanitized { bytes: out, modified, notes }
+    Sanitized {
+        bytes: out,
+        modified,
+        notes,
+    }
 }
 
 fn normalize_newlines(bytes: &[u8]) -> Vec<u8> {
@@ -139,7 +143,10 @@ mod tests {
     #[test]
     fn filename_strips_paths_and_traversal() {
         assert_eq!(sanitize_filename("../../etc/passwd"), "passwd");
-        assert_eq!(sanitize_filename("..\\..\\windows\\system32\\cmd.exe"), "cmd.exe");
+        assert_eq!(
+            sanitize_filename("..\\..\\windows\\system32\\cmd.exe"),
+            "cmd.exe"
+        );
         assert_eq!(sanitize_filename("contract.wasm"), "contract.wasm");
         assert_eq!(sanitize_filename("..."), "upload.bin");
     }

--- a/src/upload_sanitization/tests.rs
+++ b/src/upload_sanitization/tests.rs
@@ -22,7 +22,9 @@ fn full_accept_flow_with_rate_limit() {
     let now = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
 
     // Rate gate passes, then the pipeline accepts the WASM.
-    assert!(limiter.check_and_record("user-1", "203.0.113.1", now).is_ok());
+    assert!(limiter
+        .check_and_record("user-1", "203.0.113.1", now)
+        .is_ok());
     let wasm = valid_wasm();
     let req = UploadRequest {
         bytes: &wasm,

--- a/src/upload_sanitization/tests.rs
+++ b/src/upload_sanitization/tests.rs
@@ -1,0 +1,157 @@
+//! End-to-end integration tests for the upload-sanitization subsystem,
+//! combining the validation pipeline with rate limiting, quarantine and
+//! progress tracking as they would be wired in an endpoint handler.
+
+use super::*;
+use chrono::DateTime;
+use uuid::Uuid;
+
+fn valid_wasm() -> Vec<u8> {
+    let mut m = vec![0x00, 0x61, 0x73, 0x6d];
+    m.extend_from_slice(&1u32.to_le_bytes());
+    m.push(1); // type section
+    m.push(1); // length
+    m.push(0); // payload
+    m
+}
+
+#[test]
+fn full_accept_flow_with_rate_limit() {
+    let scanner = SignatureScanner::new();
+    let limiter = UploadRateLimiter::new(UploadRateConfig::default());
+    let now = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
+
+    // Rate gate passes, then the pipeline accepts the WASM.
+    assert!(limiter.check_and_record("user-1", "203.0.113.1", now).is_ok());
+    let wasm = valid_wasm();
+    let req = UploadRequest {
+        bytes: &wasm,
+        declared_content_type: "application/wasm",
+        filename: "contract.wasm",
+        tier: UploadTier::Paid,
+    };
+    assert!(validate_upload(&req, &scanner).is_accepted());
+}
+
+#[test]
+fn malicious_upload_is_rejected_and_can_be_quarantined_for_forensics() {
+    let scanner = SignatureScanner::new();
+    let mut quarantine = Quarantine::new();
+    let uploader = Uuid::new_v4();
+
+    let req = UploadRequest {
+        bytes: b"fn go() { let _ = \"/dev/tcp/10.0.0.1/4444\"; }",
+        declared_content_type: "text/x-rust",
+        filename: "payload.rs",
+        tier: UploadTier::Free,
+    };
+
+    match validate_upload(&req, &scanner) {
+        UploadVerdict::Rejected { stage, reason } => {
+            assert_eq!(stage, "deep-inspection");
+            // Operator retains the artifact for forensic review.
+            let id = quarantine.add(req.bytes, "payload.rs", uploader, reason, 1000);
+            assert_eq!(quarantine.pending_count(), 1);
+            assert!(quarantine.purge(id));
+            assert!(quarantine.get(id).unwrap().bytes.is_none());
+        }
+        other => panic!("expected rejection, got {other:?}"),
+    }
+}
+
+#[test]
+fn suspicious_upload_routes_to_quarantine_for_review() {
+    let scanner = SignatureScanner::new();
+    let mut quarantine = Quarantine::new();
+    let uploader = Uuid::new_v4();
+
+    let req = UploadRequest {
+        bytes: b"let cfg = include_str!(\"../../config/secrets.toml\");",
+        declared_content_type: "text/x-rust",
+        filename: "loader.rs",
+        tier: UploadTier::Free,
+    };
+
+    match validate_upload(&req, &scanner) {
+        UploadVerdict::Quarantined { reason, filename } => {
+            let id = quarantine.add(req.bytes, filename, uploader, reason, 1000);
+            // A reviewer clears the false positive and recovers the bytes.
+            let released = quarantine.release(id).unwrap();
+            assert_eq!(released, req.bytes);
+        }
+        other => panic!("expected quarantine, got {other:?}"),
+    }
+}
+
+#[test]
+fn tiers_gate_large_uploads_consistently() {
+    let scanner = SignatureScanner::new();
+    // ~5 MB of realistic multi-line source (short lines avoid the
+    // overlong-line obfuscation heuristic).
+    let line = b"pub fn helper_value() -> i32 { 42 }\n";
+    let mut payload = Vec::with_capacity(5 * 1024 * 1024 + line.len());
+    while payload.len() < 5 * 1024 * 1024 {
+        payload.extend_from_slice(line);
+    }
+
+    // Free tier (1 MB) rejects.
+    let free = UploadRequest {
+        bytes: &payload,
+        declared_content_type: "text/plain",
+        filename: "big.rs",
+        tier: UploadTier::Free,
+    };
+    assert!(matches!(
+        validate_upload(&free, &scanner),
+        UploadVerdict::Rejected { .. }
+    ));
+
+    // Paid tier (10 MB) accepts the same content.
+    let paid = UploadRequest {
+        bytes: &payload,
+        declared_content_type: "text/plain",
+        filename: "big.rs",
+        tier: UploadTier::Paid,
+    };
+    assert!(validate_upload(&paid, &scanner).is_accepted());
+}
+
+#[test]
+fn upload_progress_completes_then_pipeline_runs() {
+    // Simulate streaming a WASM upload to completion before validation.
+    let wasm = valid_wasm();
+    let mut progress = UploadProgress::start(wasm.len() as u64, 1000, 30);
+    let mut t = 1000;
+    for chunk in wasm.chunks(3) {
+        t += 1;
+        progress.record_chunk(chunk.len() as u64, t);
+    }
+    assert!(progress.is_complete());
+
+    let scanner = SignatureScanner::new();
+    let req = UploadRequest {
+        bytes: &wasm,
+        declared_content_type: "application/wasm",
+        filename: "contract.wasm",
+        tier: UploadTier::Free,
+    };
+    assert!(validate_upload(&req, &scanner).is_accepted());
+}
+
+#[test]
+fn rate_limit_blocks_flood_from_one_ip() {
+    let limiter = UploadRateLimiter::new(UploadRateConfig {
+        per_user_hourly: 1000,
+        per_ip_hourly: 5,
+    });
+    let now = DateTime::from_timestamp(1_700_000_000, 0).unwrap();
+    for i in 0..5 {
+        assert!(limiter
+            .check_and_record(&format!("user-{i}"), "198.51.100.7", now)
+            .is_ok());
+    }
+    assert_eq!(
+        limiter.check_and_record("user-x", "198.51.100.7", now),
+        Err(RateScope::Ip)
+    );
+}

--- a/src/upload_sanitization/wasm.rs
+++ b/src/upload_sanitization/wasm.rs
@@ -1,0 +1,181 @@
+//! Structural validation of WebAssembly modules.
+//!
+//! Verifies the 8-byte preamble (magic + version) and walks the section
+//! framing (id + LEB128 length) to ensure the module is well-formed and free
+//! of malformed/oversized section declarations that could exploit a downstream
+//! parser. This is a structural sanity check, not a full Wasm validator.
+
+use crate::upload_sanitization::magic::WASM_MAGIC;
+use serde::{Deserialize, Serialize};
+
+/// The only WebAssembly binary format version currently accepted.
+pub const SUPPORTED_VERSION: u32 = 1;
+/// Highest known section id (12 = data count, Wasm MVP + bulk-memory).
+const MAX_KNOWN_SECTION_ID: u8 = 12;
+
+/// Summary of a structurally validated module.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WasmInfo {
+    /// Binary-format version from the preamble.
+    pub version: u32,
+    /// Section ids encountered, in order.
+    pub section_ids: Vec<u8>,
+}
+
+/// Why a WASM module failed structural validation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WasmError {
+    /// Shorter than the 8-byte preamble.
+    TooShort,
+    /// Missing `\0asm` magic.
+    BadMagic,
+    /// Unsupported binary-format version.
+    UnsupportedVersion(u32),
+    /// A section's declared length runs past the end of the file.
+    SectionOverrun {
+        /// The offending section id.
+        section_id: u8,
+    },
+    /// A section uses an unknown id (possible parser-exploitation attempt).
+    UnknownSection(u8),
+    /// A LEB128 length field was malformed (overlong / truncated).
+    BadLeb128,
+}
+
+/// Structurally validates a WebAssembly module.
+pub fn validate(bytes: &[u8]) -> Result<WasmInfo, WasmError> {
+    if bytes.len() < 8 {
+        return Err(WasmError::TooShort);
+    }
+    if bytes[0..4] != WASM_MAGIC {
+        return Err(WasmError::BadMagic);
+    }
+    let version = u32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
+    if version != SUPPORTED_VERSION {
+        return Err(WasmError::UnsupportedVersion(version));
+    }
+
+    let mut section_ids = Vec::new();
+    let mut offset = 8;
+    while offset < bytes.len() {
+        let section_id = bytes[offset];
+        offset += 1;
+
+        let (len, consumed) = read_leb128_u32(&bytes[offset..]).ok_or(WasmError::BadLeb128)?;
+        offset += consumed;
+
+        if section_id > MAX_KNOWN_SECTION_ID {
+            return Err(WasmError::UnknownSection(section_id));
+        }
+
+        let end = offset
+            .checked_add(len as usize)
+            .ok_or(WasmError::SectionOverrun { section_id })?;
+        if end > bytes.len() {
+            return Err(WasmError::SectionOverrun { section_id });
+        }
+        section_ids.push(section_id);
+        offset = end;
+    }
+
+    Ok(WasmInfo { version, section_ids })
+}
+
+/// Reads an unsigned LEB128 u32, returning `(value, bytes_consumed)`.
+fn read_leb128_u32(bytes: &[u8]) -> Option<(u32, usize)> {
+    let mut result: u32 = 0;
+    let mut shift = 0;
+    for (i, &byte) in bytes.iter().enumerate() {
+        // u32 needs at most 5 LEB128 bytes.
+        if i >= 5 {
+            return None;
+        }
+        let low = (byte & 0x7f) as u32;
+        result |= low.checked_shl(shift)?;
+        if byte & 0x80 == 0 {
+            return Some((result, i + 1));
+        }
+        shift += 7;
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Builds a minimal valid module: preamble + one type section (id 1).
+    fn minimal_module() -> Vec<u8> {
+        let mut m = WASM_MAGIC.to_vec();
+        m.extend_from_slice(&SUPPORTED_VERSION.to_le_bytes());
+        m.push(1); // section id: type
+        m.push(2); // section length: 2 bytes
+        m.extend_from_slice(&[0x00, 0x00]); // payload
+        m
+    }
+
+    #[test]
+    fn valid_module_passes() {
+        let info = validate(&minimal_module()).unwrap();
+        assert_eq!(info.version, 1);
+        assert_eq!(info.section_ids, vec![1]);
+    }
+
+    #[test]
+    fn rejects_short_and_bad_magic() {
+        assert_eq!(validate(b"\0asm").unwrap_err(), WasmError::TooShort);
+        let mut bad = vec![0xde, 0xad, 0xbe, 0xef];
+        bad.extend_from_slice(&[1, 0, 0, 0]);
+        assert_eq!(validate(&bad).unwrap_err(), WasmError::BadMagic);
+    }
+
+    #[test]
+    fn rejects_unsupported_version() {
+        let mut m = WASM_MAGIC.to_vec();
+        m.extend_from_slice(&2u32.to_le_bytes());
+        assert_eq!(validate(&m).unwrap_err(), WasmError::UnsupportedVersion(2));
+    }
+
+    #[test]
+    fn rejects_section_overrun() {
+        let mut m = WASM_MAGIC.to_vec();
+        m.extend_from_slice(&SUPPORTED_VERSION.to_le_bytes());
+        m.push(1); // type section
+        m.push(50); // claims 50 bytes but none follow
+        assert_eq!(
+            validate(&m).unwrap_err(),
+            WasmError::SectionOverrun { section_id: 1 }
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_section() {
+        let mut m = WASM_MAGIC.to_vec();
+        m.extend_from_slice(&SUPPORTED_VERSION.to_le_bytes());
+        m.push(99); // unknown section id
+        m.push(0);
+        assert_eq!(validate(&m).unwrap_err(), WasmError::UnknownSection(99));
+    }
+
+    #[test]
+    fn rejects_malformed_leb128() {
+        let mut m = WASM_MAGIC.to_vec();
+        m.extend_from_slice(&SUPPORTED_VERSION.to_le_bytes());
+        m.push(1);
+        // Five continuation bytes with no terminator → overlong.
+        m.extend_from_slice(&[0x80, 0x80, 0x80, 0x80, 0x80]);
+        assert_eq!(validate(&m).unwrap_err(), WasmError::BadLeb128);
+    }
+
+    #[test]
+    fn leb128_multibyte_length() {
+        // Section length 130 encodes as 0x82 0x01 in LEB128.
+        let mut m = WASM_MAGIC.to_vec();
+        m.extend_from_slice(&SUPPORTED_VERSION.to_le_bytes());
+        m.push(1);
+        m.extend_from_slice(&[0x82, 0x01]);
+        m.extend_from_slice(&vec![0u8; 130]);
+        let info = validate(&m).unwrap();
+        assert_eq!(info.section_ids, vec![1]);
+    }
+}

--- a/src/upload_sanitization/wasm.rs
+++ b/src/upload_sanitization/wasm.rs
@@ -78,7 +78,10 @@ pub fn validate(bytes: &[u8]) -> Result<WasmInfo, WasmError> {
         offset = end;
     }
 
-    Ok(WasmInfo { version, section_ids })
+    Ok(WasmInfo {
+        version,
+        section_ids,
+    })
 }
 
 /// Reads an unsigned LEB128 u32, returning `(value, bytes_consumed)`.


### PR DESCRIPTION
# Input sanitization for contract-code uploads (#330)

Closes #330.

## Acceptance criteria

| # | Requirement | Status |
|---|-------------|--------|
| 1 | File-type validation via magic-number detection | ✅ `magic::detect` |
| 2 | Content-type allowlist (WASM, Rust source, …) | ✅ `content_type` |
| 3 | Deep inspection for embedded malicious patterns | ✅ `deep_inspection::inspect` |
| 4 | WASM structure validation (header, section validation) | ✅ `wasm::validate` |
| 5 | Virus/malware scanning integration | ✅ `malware::MalwareScanner` (+ EICAR-aware default) |
| 6 | Content sanitization to remove dangerous elements | ✅ `sanitize::sanitize_content` |
| 7 | Quarantine system for suspicious files | ✅ `quarantine::Quarantine` |
| 8 | Upload rate limiting per user and per IP | ✅ `limits::UploadRateLimiter` |
| 9 | Tier-based size limits (free 1MB / paid 10MB / enterprise 100MB) | ✅ `limits::UploadTier` |
| 10 | Upload progress tracking & timeout handling | ✅ `progress::UploadProgress` |
| 11 | High malicious-detection / low false-positive rate | ✅ layered checks; suspicious→quarantine instead of hard-fail |
| 12 | Comprehensive security testing | ✅ 64 tests |
