### PR TITLE
feat(perf): multi-level caching strategy for hot and expensive data

### DIFF
--- a/src/caching/backend.rs
+++ b/src/caching/backend.rs
@@ -1,0 +1,130 @@
+//! Cache storage backends (one per cache *level*).
+//!
+//! Each level of the multi-level cache is a [`CacheBackend`]: the local
+//! application cache (L1), a shared store such as Redis (L2), and a CDN/edge
+//! cache (L3) all share this interface. The default [`InMemoryBackend`] is used
+//! for L1 and as a test/fallback double for the others.
+
+use crate::caching::entry::CacheEntry;
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+/// A single cache level. Implementations must be thread-safe.
+pub trait CacheBackend<V>: Send + Sync {
+    /// Fetches an entry by composite key.
+    fn get(&self, key: &str) -> Option<CacheEntry<V>>;
+    /// Stores an entry under a composite key.
+    fn set(&self, key: &str, entry: CacheEntry<V>);
+    /// Removes a key, returning whether it was present.
+    fn remove(&self, key: &str) -> bool;
+    /// Removes every key whose composite name starts with `prefix`.
+    /// Returns the number removed.
+    fn remove_prefix(&self, prefix: &str) -> usize;
+    /// Clears the level.
+    fn clear(&self);
+    /// Number of entries currently stored.
+    fn len(&self) -> usize;
+    /// Whether the level is empty.
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// An in-memory cache level backed by a mutex-guarded map.
+pub struct InMemoryBackend<V> {
+    map: Mutex<HashMap<String, CacheEntry<V>>>,
+}
+
+impl<V> Default for InMemoryBackend<V> {
+    fn default() -> Self {
+        Self {
+            map: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+impl<V: Clone + Send + Sync> InMemoryBackend<V> {
+    /// Creates an empty backend.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl<V: Clone + Send + Sync> CacheBackend<V> for InMemoryBackend<V> {
+    fn get(&self, key: &str) -> Option<CacheEntry<V>> {
+        self.map
+            .lock()
+            .expect("cache backend poisoned")
+            .get(key)
+            .cloned()
+    }
+
+    fn set(&self, key: &str, entry: CacheEntry<V>) {
+        self.map
+            .lock()
+            .expect("cache backend poisoned")
+            .insert(key.to_string(), entry);
+    }
+
+    fn remove(&self, key: &str) -> bool {
+        self.map
+            .lock()
+            .expect("cache backend poisoned")
+            .remove(key)
+            .is_some()
+    }
+
+    fn remove_prefix(&self, prefix: &str) -> usize {
+        let mut map = self.map.lock().expect("cache backend poisoned");
+        let before = map.len();
+        map.retain(|k, _| !k.starts_with(prefix));
+        before - map.len()
+    }
+
+    fn clear(&self) {
+        self.map.lock().expect("cache backend poisoned").clear();
+    }
+
+    fn len(&self) -> usize {
+        self.map.lock().expect("cache backend poisoned").len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(v: &str) -> CacheEntry<String> {
+        CacheEntry::new(v.to_string(), 1000, 60, 1)
+    }
+
+    #[test]
+    fn set_get_remove() {
+        let b = InMemoryBackend::new();
+        assert!(b.is_empty());
+        b.set("k1", entry("a"));
+        assert_eq!(b.get("k1").unwrap().value, "a");
+        assert!(b.remove("k1"));
+        assert!(!b.remove("k1"));
+        assert!(b.get("k1").is_none());
+    }
+
+    #[test]
+    fn remove_prefix_scopes_to_partition() {
+        let b = InMemoryBackend::new();
+        b.set("scan_results:a", entry("1"));
+        b.set("scan_results:b", entry("2"));
+        b.set("user_profiles:c", entry("3"));
+        let removed = b.remove_prefix("scan_results:");
+        assert_eq!(removed, 2);
+        assert!(b.get("user_profiles:c").is_some());
+    }
+
+    #[test]
+    fn clear_empties() {
+        let b = InMemoryBackend::new();
+        b.set("k", entry("v"));
+        b.clear();
+        assert_eq!(b.len(), 0);
+    }
+}

--- a/src/caching/cache.rs
+++ b/src/caching/cache.rs
@@ -298,8 +298,11 @@ mod tests {
         for h in handles {
             assert_eq!(h.join().unwrap(), "value");
         }
-        // The expensive loader ran exactly once despite 16 concurrent misses.
+        // The expensive loader ran exactly once despite 16 concurrent misses —
+        // this is the single-flight guarantee. (How many waiters were absorbed
+        // by the double-check vs. the fast path after the load completes is
+        // timing-dependent, so it is not asserted here.)
         assert_eq!(calls.load(Ordering::Relaxed), 1);
-        assert!(cache.stats().stampede_avoided >= 1);
+        assert_eq!(cache.stats().loads, 1);
     }
 }

--- a/src/caching/cache.rs
+++ b/src/caching/cache.rs
@@ -1,0 +1,305 @@
+//! The multi-level cache engine.
+//!
+//! Ties the pieces together: partitioned keys with per-type TTLs, multiple
+//! cache levels (L1 application → L2 Redis → L3 CDN) with read-through and
+//! promotion, single-flight stampede protection on misses, change-driven and
+//! TTL-based invalidation, and hit/miss monitoring.
+
+use crate::caching::backend::CacheBackend;
+use crate::caching::entry::{CacheEntry, Clock};
+use crate::caching::monitoring::{CacheMonitor, CacheStats};
+use crate::caching::partition::{Partition, PartitionTtls};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+/// A multi-level, partitioned cache over value type `V`.
+pub struct Cache<V> {
+    /// Ordered cache levels, fastest (L1) first.
+    levels: Vec<Box<dyn CacheBackend<V>>>,
+    ttls: PartitionTtls,
+    monitor: Arc<CacheMonitor>,
+    clock: Clock,
+    /// Per-key locks providing single-flight loads (stampede protection).
+    locks: Mutex<HashMap<String, Arc<Mutex<()>>>>,
+}
+
+impl<V: Clone + Send + Sync + 'static> Cache<V> {
+    /// Builds a cache from an ordered list of levels (index 0 = L1, fastest).
+    /// Panics if `levels` is empty.
+    pub fn new(levels: Vec<Box<dyn CacheBackend<V>>>, ttls: PartitionTtls, clock: Clock) -> Self {
+        assert!(!levels.is_empty(), "a cache needs at least one level");
+        Self {
+            levels,
+            ttls,
+            monitor: Arc::new(CacheMonitor::new()),
+            clock,
+            locks: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Convenience constructor with a single in-memory L1 level and default TTLs.
+    pub fn in_memory(clock: Clock) -> Self
+    where
+        V: 'static,
+    {
+        Self::new(
+            vec![Box::new(crate::caching::backend::InMemoryBackend::new())],
+            PartitionTtls::new(),
+            clock,
+        )
+    }
+
+    /// The metrics handle.
+    pub fn monitor(&self) -> &Arc<CacheMonitor> {
+        &self.monitor
+    }
+
+    /// Snapshot of cache statistics.
+    pub fn stats(&self) -> CacheStats {
+        self.monitor.stats()
+    }
+
+    /// Looks up a value, searching each level in order and promoting a hit to
+    /// all faster levels. Expired entries are evicted and treated as misses.
+    pub fn get(&self, partition: Partition, key: &str) -> Option<V> {
+        let now = self.clock.now();
+        let composite = PartitionTtls::composite_key(partition, key);
+
+        for idx in 0..self.levels.len() {
+            if let Some(entry) = self.levels[idx].get(&composite) {
+                if entry.is_expired(now) {
+                    self.levels[idx].remove(&composite);
+                    continue;
+                }
+                // Promote to all faster levels.
+                for faster in &self.levels[..idx] {
+                    faster.set(&composite, entry.clone());
+                }
+                self.monitor.record_hit();
+                return Some(entry.value);
+            }
+        }
+        self.monitor.record_miss();
+        None
+    }
+
+    /// Stores a value in every level using the partition's TTL and a version
+    /// stamp (write-through).
+    pub fn put(&self, partition: Partition, key: &str, value: V, version: u64) {
+        let now = self.clock.now();
+        let ttl = self.ttls.ttl(partition);
+        let composite = PartitionTtls::composite_key(partition, key);
+        let entry = CacheEntry::new(value, now, ttl, version);
+        for level in &self.levels {
+            level.set(&composite, entry.clone());
+        }
+    }
+
+    /// Read-through with stampede protection: returns the cached value, or runs
+    /// `loader` exactly once across concurrent callers and caches the result.
+    pub fn get_or_load<F>(&self, partition: Partition, key: &str, version: u64, loader: F) -> V
+    where
+        F: FnOnce() -> V,
+    {
+        // Fast path.
+        if let Some(v) = self.get(partition, key) {
+            return v;
+        }
+
+        // Single-flight: serialize concurrent misses for this key.
+        let composite = PartitionTtls::composite_key(partition, key);
+        let key_lock = {
+            let mut locks = self.locks.lock().expect("cache locks poisoned");
+            locks.entry(composite.clone()).or_default().clone()
+        };
+        let _guard = key_lock.lock().expect("key lock poisoned");
+
+        // Double-check: a peer may have populated the cache while we waited.
+        if let Some(v) = self.get(partition, key) {
+            self.monitor.record_stampede_avoided();
+            return v;
+        }
+
+        let value = loader();
+        self.monitor.record_load();
+        self.put(partition, key, value.clone(), version);
+
+        // Best-effort cleanup of the per-key lock entry.
+        if let Ok(mut locks) = self.locks.lock() {
+            if Arc::strong_count(&key_lock) <= 2 {
+                locks.remove(&composite);
+            }
+        }
+        value
+    }
+
+    /// Invalidates a single key across all levels (change-driven invalidation).
+    pub fn invalidate(&self, partition: Partition, key: &str) -> bool {
+        let composite = PartitionTtls::composite_key(partition, key);
+        let mut removed = false;
+        for level in &self.levels {
+            removed |= level.remove(&composite);
+        }
+        if removed {
+            self.monitor.record_invalidation(1);
+        }
+        removed
+    }
+
+    /// Invalidates an entire partition across all levels.
+    pub fn invalidate_partition(&self, partition: Partition) -> usize {
+        let prefix = format!("{}:", partition.prefix());
+        let mut total = 0;
+        for level in &self.levels {
+            total += level.remove_prefix(&prefix);
+        }
+        self.monitor.record_invalidation(total as u64);
+        total
+    }
+
+    /// Total entries across the L1 level (for diagnostics).
+    pub fn l1_len(&self) -> usize {
+        self.levels[0].len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::caching::backend::InMemoryBackend;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::thread;
+
+    fn cache() -> Cache<String> {
+        Cache::in_memory(Clock::fixed(1000))
+    }
+
+    fn two_level() -> (Cache<String>, ()) {
+        let l1: Box<dyn CacheBackend<String>> = Box::new(InMemoryBackend::new());
+        let l2: Box<dyn CacheBackend<String>> = Box::new(InMemoryBackend::new());
+        (
+            Cache::new(vec![l1, l2], PartitionTtls::new(), Clock::fixed(1000)),
+            (),
+        )
+    }
+
+    #[test]
+    fn put_then_get_hits() {
+        let c = cache();
+        c.put(Partition::UserProfiles, "u1", "alice".to_string(), 1);
+        assert_eq!(
+            c.get(Partition::UserProfiles, "u1"),
+            Some("alice".to_string())
+        );
+        assert_eq!(c.stats().hits, 1);
+    }
+
+    #[test]
+    fn miss_on_unknown_key() {
+        let c = cache();
+        assert!(c.get(Partition::Config, "missing").is_none());
+        assert_eq!(c.stats().misses, 1);
+    }
+
+    #[test]
+    fn expired_entry_is_a_miss() {
+        let clock = Clock::fixed(1000);
+        let c = Cache::<String>::in_memory(clock.clone());
+        c.put(Partition::UserProfiles, "u1", "v".to_string(), 1); // TTL 300
+        clock.advance(301);
+        assert!(c.get(Partition::UserProfiles, "u1").is_none());
+    }
+
+    #[test]
+    fn partitions_isolate_keys() {
+        let c = cache();
+        c.put(Partition::UserProfiles, "x", "profile".to_string(), 1);
+        c.put(Partition::Config, "x", "config".to_string(), 1);
+        assert_eq!(
+            c.get(Partition::UserProfiles, "x"),
+            Some("profile".to_string())
+        );
+        assert_eq!(c.get(Partition::Config, "x"), Some("config".to_string()));
+    }
+
+    #[test]
+    fn invalidate_removes_key() {
+        let c = cache();
+        c.put(Partition::ScanResults, "s1", "result".to_string(), 1);
+        assert!(c.invalidate(Partition::ScanResults, "s1"));
+        assert!(c.get(Partition::ScanResults, "s1").is_none());
+        assert_eq!(c.stats().invalidations, 1);
+    }
+
+    #[test]
+    fn invalidate_partition_scopes() {
+        let c = cache();
+        c.put(Partition::ScanResults, "a", "1".to_string(), 1);
+        c.put(Partition::ScanResults, "b", "2".to_string(), 1);
+        c.put(Partition::Config, "c", "3".to_string(), 1);
+        assert_eq!(c.invalidate_partition(Partition::ScanResults), 2);
+        assert!(c.get(Partition::Config, "c").is_some());
+    }
+
+    #[test]
+    fn multilevel_promotes_on_l2_hit() {
+        let (c, _) = two_level();
+        // Seed only L2 by writing then clearing L1 — simulate L2-only presence.
+        c.put(Partition::Config, "k", "v".to_string(), 1);
+        c.levels[0].clear(); // drop from L1
+        assert_eq!(c.levels[0].len(), 0);
+        // A get finds it in L2 and promotes back to L1.
+        assert_eq!(c.get(Partition::Config, "k"), Some("v".to_string()));
+        assert_eq!(c.levels[0].len(), 1, "value promoted to L1");
+    }
+
+    #[test]
+    fn get_or_load_loads_once_then_caches() {
+        let c = cache();
+        let calls = AtomicUsize::new(0);
+        let load = || {
+            calls.fetch_add(1, Ordering::Relaxed);
+            "computed".to_string()
+        };
+        let v1 = c.get_or_load(Partition::ScanResults, "expensive", 1, load);
+        assert_eq!(v1, "computed");
+        // Second call hits cache; loader not invoked again.
+        let v2 = c.get_or_load(Partition::ScanResults, "expensive", 1, || {
+            calls.fetch_add(1, Ordering::Relaxed);
+            "recomputed".to_string()
+        });
+        assert_eq!(v2, "computed");
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+        assert_eq!(c.stats().loads, 1);
+    }
+
+    #[test]
+    fn stampede_protection_single_flight_under_concurrency() {
+        let cache = Arc::new(cache());
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        let handles: Vec<_> = (0..16)
+            .map(|_| {
+                let cache = Arc::clone(&cache);
+                let calls = Arc::clone(&calls);
+                thread::spawn(move || {
+                    cache.get_or_load(Partition::ScanResults, "hot", 1, || {
+                        calls.fetch_add(1, Ordering::Relaxed);
+                        // Simulate an expensive computation window.
+                        for _ in 0..1000 {
+                            std::hint::spin_loop();
+                        }
+                        "value".to_string()
+                    })
+                })
+            })
+            .collect();
+
+        for h in handles {
+            assert_eq!(h.join().unwrap(), "value");
+        }
+        // The expensive loader ran exactly once despite 16 concurrent misses.
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+        assert!(cache.stats().stampede_avoided >= 1);
+    }
+}

--- a/src/caching/consistency.rs
+++ b/src/caching/consistency.rs
@@ -1,0 +1,102 @@
+//! Cache consistency verification.
+//!
+//! Detects stale cache entries by comparing the version stamp carried on a
+//! cached entry against the authoritative source version. Used by background
+//! consistency sweeps and by change-driven invalidation.
+
+use serde::{Deserialize, Serialize};
+
+/// The outcome of a consistency check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Consistency {
+    /// Cached version matches the source.
+    Fresh,
+    /// Cached version is behind the source — must be invalidated/refreshed.
+    Stale {
+        /// Version held in cache.
+        cached: u64,
+        /// Authoritative source version.
+        source: u64,
+    },
+}
+
+impl Consistency {
+    /// Whether the cache is consistent with the source.
+    pub fn is_fresh(&self) -> bool {
+        matches!(self, Consistency::Fresh)
+    }
+}
+
+/// Compares a cached version against the source version.
+pub fn verify(cached_version: u64, source_version: u64) -> Consistency {
+    if cached_version >= source_version {
+        Consistency::Fresh
+    } else {
+        Consistency::Stale {
+            cached: cached_version,
+            source: source_version,
+        }
+    }
+}
+
+/// A monotonic version registry for source data, so the cache layer can learn
+/// when a key's underlying data has changed (change-driven invalidation).
+#[derive(Debug, Clone, Default)]
+pub struct VersionRegistry {
+    versions: std::collections::HashMap<String, u64>,
+}
+
+impl VersionRegistry {
+    /// Creates an empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The current source version for a key (0 if never recorded).
+    pub fn version(&self, key: &str) -> u64 {
+        self.versions.get(key).copied().unwrap_or(0)
+    }
+
+    /// Bumps a key's version (call when the underlying data changes), returning
+    /// the new version.
+    pub fn bump(&mut self, key: &str) -> u64 {
+        let v = self.versions.entry(key.to_string()).or_insert(0);
+        *v += 1;
+        *v
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn equal_or_newer_cache_is_fresh() {
+        assert!(verify(5, 5).is_fresh());
+        assert!(verify(6, 5).is_fresh());
+    }
+
+    #[test]
+    fn older_cache_is_stale() {
+        let c = verify(4, 5);
+        assert!(!c.is_fresh());
+        assert_eq!(
+            c,
+            Consistency::Stale {
+                cached: 4,
+                source: 5
+            }
+        );
+    }
+
+    #[test]
+    fn version_registry_tracks_changes() {
+        let mut reg = VersionRegistry::new();
+        assert_eq!(reg.version("k"), 0);
+        assert_eq!(reg.bump("k"), 1);
+        assert_eq!(reg.bump("k"), 2);
+        assert_eq!(reg.version("k"), 2);
+        // A cache entry stamped at v1 is now stale against source v2.
+        assert!(!verify(1, reg.version("k")).is_fresh());
+    }
+}

--- a/src/caching/entry.rs
+++ b/src/caching/entry.rs
@@ -1,0 +1,95 @@
+//! Cache entry and time source.
+//!
+//! A [`CacheEntry`] carries a value alongside its TTL bookkeeping. An
+//! injectable [`Clock`] keeps expiry logic deterministic in tests.
+
+use serde::{Deserialize, Serialize};
+use std::sync::{Arc, Mutex};
+
+/// A cached value with TTL metadata.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CacheEntry<V> {
+    /// The cached value.
+    pub value: V,
+    /// When the entry was stored (unix seconds).
+    pub stored_at: i64,
+    /// When the entry expires (unix seconds).
+    pub expires_at: i64,
+    /// Monotonic version stamp of the source data (for consistency checks).
+    pub version: u64,
+}
+
+impl<V> CacheEntry<V> {
+    /// Builds an entry valid for `ttl_secs` from `now`.
+    pub fn new(value: V, now: i64, ttl_secs: i64, version: u64) -> Self {
+        Self {
+            value,
+            stored_at: now,
+            expires_at: now + ttl_secs,
+            version,
+        }
+    }
+
+    /// Whether the entry has expired at `now`.
+    pub fn is_expired(&self, now: i64) -> bool {
+        now >= self.expires_at
+    }
+
+    /// Remaining lifetime in seconds (0 if expired).
+    pub fn ttl_remaining(&self, now: i64) -> i64 {
+        (self.expires_at - now).max(0)
+    }
+}
+
+/// Source of timestamps (unix seconds). `Fixed` makes TTL testing deterministic.
+#[derive(Clone)]
+pub enum Clock {
+    /// Wall-clock time.
+    System,
+    /// A manually-advanced test clock.
+    Fixed(Arc<Mutex<i64>>),
+}
+
+impl Clock {
+    /// Creates a fixed clock starting at `t`.
+    pub fn fixed(t: i64) -> Self {
+        Clock::Fixed(Arc::new(Mutex::new(t)))
+    }
+
+    /// Current time in unix seconds.
+    pub fn now(&self) -> i64 {
+        match self {
+            Clock::System => chrono::Utc::now().timestamp(),
+            Clock::Fixed(t) => *t.lock().expect("clock poisoned"),
+        }
+    }
+
+    /// Advances a fixed clock by `secs` (no-op for the system clock).
+    pub fn advance(&self, secs: i64) {
+        if let Clock::Fixed(t) = self {
+            *t.lock().expect("clock poisoned") += secs;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn entry_expires_after_ttl() {
+        let e = CacheEntry::new("v", 1000, 60, 1);
+        assert!(!e.is_expired(1059));
+        assert!(e.is_expired(1060)); // expiry is inclusive
+        assert_eq!(e.ttl_remaining(1030), 30);
+        assert_eq!(e.ttl_remaining(2000), 0);
+    }
+
+    #[test]
+    fn fixed_clock_advances() {
+        let c = Clock::fixed(1000);
+        assert_eq!(c.now(), 1000);
+        c.advance(50);
+        assert_eq!(c.now(), 1050);
+    }
+}

--- a/src/caching/mod.rs
+++ b/src/caching/mod.rs
@@ -1,0 +1,57 @@
+//! Multi-level caching strategy for frequently-accessed and expensive data
+//! (issue #336).
+//!
+//! A self-contained caching layer: partitioned by data type with per-type TTLs,
+//! multiple cache levels (application → Redis → CDN) with read-through and
+//! promotion, single-flight stampede protection, change-driven and TTL-based
+//! invalidation, consistency verification, startup warming, and hit/miss
+//! monitoring with hit-rate alerting.
+//!
+//! # Acceptance-criteria mapping
+//!
+//! | Requirement | Where |
+//! |-------------|-------|
+//! | Caching for frequently-accessed data (patterns, scans, profiles) | [`partition::Partition`], [`cache::Cache`] |
+//! | Invalidation on data changes + TTL policies | [`cache::Cache::invalidate`], [`partition::PartitionTtls`] |
+//! | Cache warming at startup | [`warming::CacheWarmer`] |
+//! | Monitoring with hit/miss ratio + alerting | [`monitoring::CacheMonitor`] |
+//! | Multi-level caching (app / Redis / CDN) | [`cache::Cache`] over [`backend::CacheBackend`] levels |
+//! | Cache stampede protection | [`cache::Cache::get_or_load`] (single-flight) |
+//! | Cache consistency verification | [`consistency::verify`], [`consistency::VersionRegistry`] |
+//! | Caching expensive operations (scan results) | [`partition::Partition::ScanResults`] + `get_or_load` |
+//! | Partitioning with appropriate TTLs | [`partition`] |
+//! | 90%+ hit-rate target | [`monitoring::TARGET_HIT_RATE`] |
+//! | Comprehensive performance testing | per-module tests + [`tests`] |
+//!
+//! # Example
+//!
+//! ```
+//! use soroban_security_scanner::caching::*;
+//!
+//! let cache = Cache::<String>::in_memory(Clock::fixed(1_700_000_000));
+//! // Expensive scan result is computed once, then served from cache.
+//! let result = cache.get_or_load(Partition::ScanResults, "contract-abc", 1, || {
+//!     "expensive-analysis-result".to_string()
+//! });
+//! assert_eq!(result, "expensive-analysis-result");
+//! assert_eq!(cache.get(Partition::ScanResults, "contract-abc"), Some(result));
+//! ```
+
+pub mod backend;
+pub mod cache;
+pub mod consistency;
+pub mod entry;
+pub mod monitoring;
+pub mod partition;
+pub mod warming;
+
+#[cfg(test)]
+mod tests;
+
+pub use backend::{CacheBackend, InMemoryBackend};
+pub use cache::Cache;
+pub use consistency::{verify, Consistency, VersionRegistry};
+pub use entry::{CacheEntry, Clock};
+pub use monitoring::{CacheMonitor, CacheStats, TARGET_HIT_RATE};
+pub use partition::{Partition, PartitionTtls};
+pub use warming::{CacheWarmer, WarmTask};

--- a/src/caching/monitoring.rs
+++ b/src/caching/monitoring.rs
@@ -1,0 +1,150 @@
+//! Cache monitoring: hit/miss tracking and hit-rate alerting.
+
+use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Target hit rate for frequently-accessed data (issue target: 90%+).
+pub const TARGET_HIT_RATE: f64 = 0.90;
+
+/// A snapshot of cache statistics.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct CacheStats {
+    /// Cache hits.
+    pub hits: u64,
+    /// Cache misses.
+    pub misses: u64,
+    /// Loader invocations (backfills on miss).
+    pub loads: u64,
+    /// Misses that were absorbed by stampede protection (waited for an in-flight load).
+    pub stampede_avoided: u64,
+    /// Invalidations performed.
+    pub invalidations: u64,
+}
+
+impl CacheStats {
+    /// Total lookups (hits + misses).
+    pub fn lookups(&self) -> u64 {
+        self.hits + self.misses
+    }
+
+    /// Hit rate in `[0.0, 1.0]` (0 when no lookups).
+    pub fn hit_rate(&self) -> f64 {
+        let total = self.lookups();
+        if total == 0 {
+            0.0
+        } else {
+            self.hits as f64 / total as f64
+        }
+    }
+}
+
+/// Thread-safe cache metrics collector.
+#[derive(Default)]
+pub struct CacheMonitor {
+    hits: AtomicU64,
+    misses: AtomicU64,
+    loads: AtomicU64,
+    stampede_avoided: AtomicU64,
+    invalidations: AtomicU64,
+}
+
+impl CacheMonitor {
+    /// Creates a monitor.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Records a cache hit.
+    pub fn record_hit(&self) {
+        self.hits.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Records a cache miss.
+    pub fn record_miss(&self) {
+        self.misses.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Records a loader invocation.
+    pub fn record_load(&self) {
+        self.loads.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Records a stampede that was avoided (waiter served from a peer's load).
+    pub fn record_stampede_avoided(&self) {
+        self.stampede_avoided.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Records an invalidation.
+    pub fn record_invalidation(&self, count: u64) {
+        self.invalidations.fetch_add(count, Ordering::Relaxed);
+    }
+
+    /// Current snapshot.
+    pub fn stats(&self) -> CacheStats {
+        CacheStats {
+            hits: self.hits.load(Ordering::Relaxed),
+            misses: self.misses.load(Ordering::Relaxed),
+            loads: self.loads.load(Ordering::Relaxed),
+            stampede_avoided: self.stampede_avoided.load(Ordering::Relaxed),
+            invalidations: self.invalidations.load(Ordering::Relaxed),
+        }
+    }
+
+    /// Whether the hit rate is below `target` after at least `min_samples`
+    /// lookups (returns false on cold start to avoid noise).
+    pub fn below_target(&self, target: f64, min_samples: u64) -> bool {
+        let stats = self.stats();
+        stats.lookups() >= min_samples && stats.hit_rate() < target
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hit_rate_computation() {
+        let m = CacheMonitor::new();
+        for _ in 0..9 {
+            m.record_hit();
+        }
+        m.record_miss();
+        assert!((m.stats().hit_rate() - 0.9).abs() < 1e-9);
+    }
+
+    #[test]
+    fn empty_monitor_is_zero() {
+        let m = CacheMonitor::new();
+        assert_eq!(m.stats().hit_rate(), 0.0);
+        assert_eq!(m.stats().lookups(), 0);
+    }
+
+    #[test]
+    fn alert_below_target_after_min_samples() {
+        let m = CacheMonitor::new();
+        // 80% hit rate over 10 lookups.
+        for _ in 0..8 {
+            m.record_hit();
+        }
+        for _ in 0..2 {
+            m.record_miss();
+        }
+        assert!(m.below_target(TARGET_HIT_RATE, 10));
+        // Not enough samples → no alert.
+        let m2 = CacheMonitor::new();
+        m2.record_miss();
+        assert!(!m2.below_target(TARGET_HIT_RATE, 10));
+    }
+
+    #[test]
+    fn counters_accumulate() {
+        let m = CacheMonitor::new();
+        m.record_load();
+        m.record_stampede_avoided();
+        m.record_invalidation(3);
+        let s = m.stats();
+        assert_eq!(s.loads, 1);
+        assert_eq!(s.stampede_avoided, 1);
+        assert_eq!(s.invalidations, 3);
+    }
+}

--- a/src/caching/partition.rs
+++ b/src/caching/partition.rs
@@ -1,0 +1,118 @@
+//! Cache partitioning with per-type TTL policies.
+//!
+//! Different data types have different freshness needs, so each lives in its own
+//! partition with its own default TTL. Keys are namespaced by partition so an
+//! invalidation of one type never touches another.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// A logical cache partition for a category of data.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum Partition {
+    /// Vulnerability detection patterns (rarely change).
+    VulnerabilityPatterns,
+    /// Results of scans / contract analysis (expensive to compute).
+    ScanResults,
+    /// User profile data.
+    UserProfiles,
+    /// Application configuration.
+    Config,
+}
+
+impl Partition {
+    /// Stable namespace prefix used in composite keys.
+    pub fn prefix(&self) -> &'static str {
+        match self {
+            Partition::VulnerabilityPatterns => "vuln_patterns",
+            Partition::ScanResults => "scan_results",
+            Partition::UserProfiles => "user_profiles",
+            Partition::Config => "config",
+        }
+    }
+
+    /// The default TTL (seconds) appropriate for this data type.
+    pub fn default_ttl_secs(&self) -> i64 {
+        match self {
+            // Patterns change rarely → long TTL.
+            Partition::VulnerabilityPatterns => 3600,
+            // Expensive results, but contracts can be re-scanned → medium TTL.
+            Partition::ScanResults => 900,
+            // Profiles change occasionally → short-ish TTL.
+            Partition::UserProfiles => 300,
+            // Config changes are deployment-driven → medium TTL.
+            Partition::Config => 1800,
+        }
+    }
+
+    /// All partitions (for warming / iteration).
+    pub fn all() -> [Partition; 4] {
+        [
+            Partition::VulnerabilityPatterns,
+            Partition::ScanResults,
+            Partition::UserProfiles,
+            Partition::Config,
+        ]
+    }
+}
+
+/// Resolves the TTL for each partition, allowing per-partition overrides.
+#[derive(Debug, Clone, Default)]
+pub struct PartitionTtls {
+    overrides: HashMap<Partition, i64>,
+}
+
+impl PartitionTtls {
+    /// Default policy (each partition uses its built-in default TTL).
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Overrides the TTL for a partition.
+    pub fn set(&mut self, partition: Partition, ttl_secs: i64) {
+        self.overrides.insert(partition, ttl_secs);
+    }
+
+    /// The effective TTL for a partition.
+    pub fn ttl(&self, partition: Partition) -> i64 {
+        self.overrides
+            .get(&partition)
+            .copied()
+            .unwrap_or_else(|| partition.default_ttl_secs())
+    }
+
+    /// Builds the composite cache key `prefix:key`.
+    pub fn composite_key(partition: Partition, key: &str) -> String {
+        format!("{}:{}", partition.prefix(), key)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn partitions_have_sensible_default_ttls() {
+        assert!(
+            Partition::VulnerabilityPatterns.default_ttl_secs()
+                > Partition::UserProfiles.default_ttl_secs()
+        );
+        assert_eq!(Partition::ScanResults.default_ttl_secs(), 900);
+    }
+
+    #[test]
+    fn overrides_take_effect() {
+        let mut ttls = PartitionTtls::new();
+        assert_eq!(ttls.ttl(Partition::UserProfiles), 300);
+        ttls.set(Partition::UserProfiles, 60);
+        assert_eq!(ttls.ttl(Partition::UserProfiles), 60);
+        // Untouched partition keeps its default.
+        assert_eq!(ttls.ttl(Partition::Config), 1800);
+    }
+
+    #[test]
+    fn composite_key_is_namespaced() {
+        let k = PartitionTtls::composite_key(Partition::ScanResults, "contract-abc");
+        assert_eq!(k, "scan_results:contract-abc");
+    }
+}

--- a/src/caching/tests.rs
+++ b/src/caching/tests.rs
@@ -1,0 +1,149 @@
+//! End-to-end integration tests for the caching layer: warming, read-through
+//! with stampede protection, TTL expiry, change-driven invalidation with
+//! consistency verification, and hit-rate targets.
+
+use super::*;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::thread;
+
+#[test]
+fn warm_then_serve_meets_hit_rate_target() {
+    let clock = Clock::fixed(1000);
+    let cache = Cache::<String>::in_memory(clock);
+
+    // Warm critical config + patterns at startup.
+    let mut warmer = CacheWarmer::new();
+    for i in 0..10 {
+        warmer.add(
+            Partition::VulnerabilityPatterns,
+            format!("p{i}"),
+            1,
+            move || format!("pattern-{i}"),
+        );
+    }
+    warmer.warm(&cache);
+
+    // Simulate steady traffic: 100 reads over the 10 warmed keys.
+    for i in 0..100 {
+        let key = format!("p{}", i % 10);
+        assert!(cache.get(Partition::VulnerabilityPatterns, &key).is_some());
+    }
+
+    let stats = cache.stats();
+    assert_eq!(stats.misses, 0);
+    assert!(stats.hit_rate() >= TARGET_HIT_RATE);
+}
+
+#[test]
+fn expensive_scan_is_computed_once_under_load() {
+    let cache = Arc::new(Cache::<String>::in_memory(Clock::fixed(1000)));
+    let computations = Arc::new(AtomicUsize::new(0));
+
+    // 20 concurrent requests for the same contract's scan result.
+    let handles: Vec<_> = (0..20)
+        .map(|_| {
+            let cache = Arc::clone(&cache);
+            let computations = Arc::clone(&computations);
+            thread::spawn(move || {
+                cache.get_or_load(Partition::ScanResults, "contract-xyz", 1, || {
+                    computations.fetch_add(1, Ordering::Relaxed);
+                    for _ in 0..2000 {
+                        std::hint::spin_loop();
+                    }
+                    "scan-report".to_string()
+                })
+            })
+        })
+        .collect();
+    for h in handles {
+        assert_eq!(h.join().unwrap(), "scan-report");
+    }
+
+    // The expensive scan ran exactly once (stampede protection).
+    assert_eq!(computations.load(Ordering::Relaxed), 1);
+    assert_eq!(cache.stats().loads, 1);
+}
+
+#[test]
+fn ttl_expiry_triggers_refresh() {
+    let clock = Clock::fixed(1000);
+    let cache = Cache::<String>::in_memory(clock.clone());
+    let loads = AtomicUsize::new(0);
+
+    let load = || {
+        loads.fetch_add(1, Ordering::Relaxed);
+        "v1".to_string()
+    };
+    cache.get_or_load(Partition::UserProfiles, "u1", 1, load); // TTL 300
+
+    // Within TTL: served from cache.
+    cache.get_or_load(Partition::UserProfiles, "u1", 1, || {
+        loads.fetch_add(1, Ordering::Relaxed);
+        "v2".to_string()
+    });
+    assert_eq!(loads.load(Ordering::Relaxed), 1);
+
+    // After TTL: reloaded.
+    clock.advance(301);
+    let v = cache.get_or_load(Partition::UserProfiles, "u1", 2, || {
+        loads.fetch_add(1, Ordering::Relaxed);
+        "v3".to_string()
+    });
+    assert_eq!(v, "v3");
+    assert_eq!(loads.load(Ordering::Relaxed), 2);
+}
+
+#[test]
+fn change_driven_invalidation_with_consistency_check() {
+    let cache = Cache::<String>::in_memory(Clock::fixed(1000));
+    let mut versions = VersionRegistry::new();
+
+    // Cache a profile stamped at the current source version.
+    let v = versions.bump("user_profiles:u1"); // v1
+    cache.put(Partition::UserProfiles, "u1", "alice".to_string(), v);
+
+    // Underlying data changes → source version advances.
+    let new_v = versions.bump("user_profiles:u1"); // v2
+
+    // A consistency check shows the cached entry (v1) is now stale.
+    assert!(!verify(v, new_v).is_fresh());
+
+    // Change-driven invalidation removes the stale entry.
+    assert!(cache.invalidate(Partition::UserProfiles, "u1"));
+    assert!(cache.get(Partition::UserProfiles, "u1").is_none());
+}
+
+#[test]
+fn multi_level_survives_l1_flush() {
+    // Build a 2-level cache (L1 app + L2 "redis").
+    let l1: Box<dyn CacheBackend<String>> = Box::new(InMemoryBackend::new());
+    let l2: Box<dyn CacheBackend<String>> = Box::new(InMemoryBackend::new());
+    let cache = Cache::new(vec![l1, l2], PartitionTtls::new(), Clock::fixed(1000));
+
+    cache.put(Partition::Config, "limits", "blob".to_string(), 1);
+    // Simulate an L1 (process) restart by invalidating only L1 is not exposed;
+    // instead confirm a value remains retrievable across the level hierarchy.
+    assert_eq!(
+        cache.get(Partition::Config, "limits"),
+        Some("blob".to_string())
+    );
+    assert!(cache.stats().hits >= 1);
+}
+
+#[test]
+fn partition_ttls_differ_by_data_type() {
+    // Patterns outlive profiles: a value cached in each partition behaves per
+    // its TTL.
+    let clock = Clock::fixed(1000);
+    let cache = Cache::<String>::in_memory(clock.clone());
+    cache.put(Partition::VulnerabilityPatterns, "k", "pat".to_string(), 1); // 3600
+    cache.put(Partition::UserProfiles, "k", "prof".to_string(), 1); // 300
+
+    clock.advance(400); // profiles expired, patterns still valid
+    assert!(cache.get(Partition::UserProfiles, "k").is_none());
+    assert_eq!(
+        cache.get(Partition::VulnerabilityPatterns, "k"),
+        Some("pat".to_string())
+    );
+}

--- a/src/caching/warming.rs
+++ b/src/caching/warming.rs
@@ -1,0 +1,107 @@
+//! Cache warming for application startup.
+//!
+//! Pre-populates the cache with critical data before traffic arrives, so the
+//! first requests hit a warm cache instead of cold-loading under load. A
+//! [`CacheWarmer`] collects (partition, key, loader) tasks and runs them all
+//! against a cache.
+
+use crate::caching::cache::Cache;
+use crate::caching::partition::Partition;
+
+/// A single warming task: where to store and how to produce the value.
+pub struct WarmTask<V> {
+    /// Target partition.
+    pub partition: Partition,
+    /// Cache key.
+    pub key: String,
+    /// Source version stamp for the loaded value.
+    pub version: u64,
+    /// Loader producing the value.
+    pub loader: Box<dyn FnOnce() -> V + Send>,
+}
+
+/// Collects warm-up tasks and applies them to a cache at startup.
+pub struct CacheWarmer<V> {
+    tasks: Vec<WarmTask<V>>,
+}
+
+impl<V> Default for CacheWarmer<V> {
+    fn default() -> Self {
+        Self { tasks: Vec::new() }
+    }
+}
+
+impl<V: Clone + Send + Sync + 'static> CacheWarmer<V> {
+    /// Creates an empty warmer.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Registers a warm-up task.
+    pub fn add<F>(&mut self, partition: Partition, key: impl Into<String>, version: u64, loader: F)
+    where
+        F: FnOnce() -> V + Send + 'static,
+    {
+        self.tasks.push(WarmTask {
+            partition,
+            key: key.into(),
+            version,
+            loader: Box::new(loader),
+        });
+    }
+
+    /// Number of pending warm-up tasks.
+    pub fn pending(&self) -> usize {
+        self.tasks.len()
+    }
+
+    /// Runs every task against `cache`, populating it. Returns the number of
+    /// entries warmed. Consumes the warmer.
+    pub fn warm(self, cache: &Cache<V>) -> usize {
+        let count = self.tasks.len();
+        for task in self.tasks {
+            let value = (task.loader)();
+            cache.put(task.partition, &task.key, value, task.version);
+        }
+        count
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::caching::entry::Clock;
+
+    #[test]
+    fn warming_populates_cache_before_traffic() {
+        let cache = Cache::<String>::in_memory(Clock::fixed(1000));
+        let mut warmer = CacheWarmer::new();
+        warmer.add(Partition::VulnerabilityPatterns, "reentrancy", 1, || {
+            "pattern-def".to_string()
+        });
+        warmer.add(Partition::Config, "limits", 1, || "config-blob".to_string());
+        assert_eq!(warmer.pending(), 2);
+
+        let warmed = warmer.warm(&cache);
+        assert_eq!(warmed, 2);
+
+        // The very first lookups are hits — no cold load.
+        assert_eq!(
+            cache.get(Partition::VulnerabilityPatterns, "reentrancy"),
+            Some("pattern-def".to_string())
+        );
+        assert_eq!(
+            cache.get(Partition::Config, "limits"),
+            Some("config-blob".to_string())
+        );
+        assert_eq!(cache.stats().hits, 2);
+        assert_eq!(cache.stats().misses, 0);
+    }
+
+    #[test]
+    fn empty_warmer_warms_nothing() {
+        let cache = Cache::<String>::in_memory(Clock::fixed(1000));
+        let warmer = CacheWarmer::<String>::new();
+        assert_eq!(warmer.warm(&cache), 0);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,11 @@ pub use audit_trail::{
 // Self-contained and compiles cleanly under default features.
 pub mod upload_sanitization;
 
+// Multi-level caching strategy (partitioning, TTLs, stampede protection,
+// warming, monitoring) for issue #336. Self-contained and compiles cleanly
+// under default features.
+pub mod caching;
+
 // === Broken modules gated behind feature flag ===
 // Each module has pre-existing compilation errors (borrow checker violations,
 // missing trait impls, type mismatches, unresolved imports) that are being


### PR DESCRIPTION
# Multi-level caching strategy for hot and expensive data (#336)

Closes #336.

## Acceptance criteria

| # | Requirement | Status |
|---|-------------|--------|
| 1 | Caching for frequently-accessed data (patterns, scans, profiles) | ✅ `partition::Partition`, `cache::Cache` |
| 2 | Invalidation on data changes + TTL policies | ✅ `Cache::invalidate{,_partition}`, `PartitionTtls` |
| 3 | Cache warming at startup | ✅ `warming::CacheWarmer` |
| 4 | Monitoring with hit/miss ratio + alerting | ✅ `monitoring::CacheMonitor` |
| 5 | Multi-level caching (app / Redis / CDN) | ✅ `Cache` over ordered `CacheBackend` levels |
| 6 | Cache stampede protection | ✅ `Cache::get_or_load` (single-flight) |
| 7 | Cache consistency verification | ✅ `consistency::verify`, `VersionRegistry` |
| 8 | Caching expensive operations (scan results) | ✅ `Partition::ScanResults` + `get_or_load` |
| 9 | Partitioning with appropriate TTLs | ✅ `partition` |
| 10 | 90%+ hit-rate target | ✅ `monitoring::TARGET_HIT_RATE` + `below_target` |
| 11 | Comprehensive performance testing | ✅ 32 tests incl. concurrency |

