### PR TITLE
feat(i18n): RTL language support for Arabic and Hebrew (Issue #436)

### DIFF
--- a/I18N_README.md
+++ b/I18N_README.md
@@ -194,6 +194,177 @@ document.documentElement.dir = direction; // 'rtl' or 'ltr'
 document.body.classList.add('rtl'); // or 'ltr'
 ```
 
+## RTL Language Support (Layout & Direction)
+
+Right-to-left support is implemented end-to-end: the `<html>` element gets the
+correct `dir` attribute, Tailwind `rtl:` variants are enabled, and layout
+primitives (`RtlContainer`, `RtlAwareIcon`) mirror direction-sensitive UI.
+
+### Supported RTL locales
+
+| Language | Code | Direction |
+|----------|------|-----------|
+| Arabic | `ar` | RTL ✅ |
+| Hebrew | `he` | RTL ✅ |
+| Persian | `fa` | RTL ✅ |
+| Urdu | `ur` | RTL ✅ |
+| English | `en` | LTR |
+| Spanish | `es` | LTR |
+
+### How `RTL_LOCALES` works
+
+Each package keeps a **single authoritative `RTL_LOCALES` constant** — no other
+code hard-codes `ar`/`he` checks:
+
+- `src/i18n/config.js` → `RTL_LOCALES` (CLI / Node)
+- `component-library/src/i18n/config.ts` → `RTL_LOCALES` (UI components)
+- `frontend/lib/i18n/rtl.ts` → `RTL_LOCALES` (Next.js frontend)
+
+`isRTL(locale)` and `getTextDirection(locale)` are derived from the constant, so
+adding a locale to `RTL_LOCALES` is all that is required to make it render RTL.
+
+```ts
+// frontend/lib/i18n/rtl.ts
+export const RTL_LOCALES = ['ar', 'he', 'fa', 'ur'] as const;
+export function getTextDirection(locale: string): 'ltr' | 'rtl' {
+  return RTL_LOCALES.includes(locale as any) ? 'rtl' : 'ltr';
+}
+```
+
+### Dynamic HTML direction
+
+`frontend/app/layout.tsx` reads the active locale from the `NEXT_LOCALE` cookie
+(never from browser heuristics) and renders:
+
+```tsx
+const locale = cookieStore.get('NEXT_LOCALE')?.value || 'en';
+const dir = getTextDirection(locale);
+
+return <html lang={locale} dir={dir}>…</html>;
+```
+
+- `ar` / `he` → `<html dir="rtl">`
+- `en` / `es` / other LTR locales → `<html dir="ltr">`
+
+The locale store (`frontend/store/localeStore.ts`) persists the choice in the
+cookie and flips `document.documentElement.dir` immediately on change. The
+`LocaleProvider` syncs the server-rendered locale into the client store after
+hydration, so there are **no hydration mismatches**.
+
+### Tailwind `rtl:` variants
+
+`frontend/tailwind.config.a11y.js` registers an `rtl:` variant:
+
+```js
+plugin(({ addVariant }) => {
+  addVariant('rtl', '&:where([dir="rtl"], [dir="rtl"] *)');
+});
+```
+
+This enables direction-aware utilities such as `rtl:ml-4`, `rtl:text-right`,
+`rtl:flex-row-reverse`, `rtl:mr-0`, `rtl:pr-3`. Because the frontend ships its
+own compiled CSS (`app/globals.css`) rather than a Tailwind build step, the same
+logical utilities (`ms-*`, `me-*`, `ps-*`, `pe-*`, `text-start`, `text-end` and
+RTL `space-x-*` swaps) are also defined there, scoped to `[dir="rtl"]` so LTR
+layouts are unaffected.
+
+### `useTextDirection()`
+
+`frontend/hooks/useTextDirection.ts` returns the direction of the active locale:
+
+```tsx
+import { useTextDirection } from '@/hooks/useTextDirection';
+
+function Header() {
+  const direction = useTextDirection(); // 'ltr' | 'rtl'
+  return <div dir={direction}>…</div>;
+}
+```
+
+It reads the locale store and re-renders on locale changes.
+
+### Building RTL-aware components
+
+**`RtlContainer`** (`component-library/src/components/RtlContainer.tsx`) applies
+the text direction to its subtree and optionally swaps the flex row direction:
+
+```tsx
+import { RtlContainer } from '@soroban-scanner/ui-components';
+
+<RtlContainer dir={direction} className="app-shell">
+  <nav>…</nav>
+</RtlContainer>
+```
+
+It is direction-neutral by default (nothing is forced unless a prop asks for
+it), renders as any element (`as`), and exposes its direction to descendants
+via context.
+
+**`RtlAwareIcon`** (`component-library/src/components/RtlAwareIcon.tsx`)
+mirrors directional icons in RTL:
+
+```tsx
+import { RtlAwareIcon } from '@soroban-scanner/ui-components';
+
+{/* Arrow/chevron — mirrored in RTL so it points along the reading direction */}
+<RtlAwareIcon directional name="arrow-right" icon={<ArrowRight />} />
+
+{/* Direction-neutral icon — never mirrored */}
+<RtlAwareIcon name="search" icon={<Search />} />
+```
+
+### When directional icons should be mirrored
+
+Mirror **arrows, chevrons and navigation indicators** (e.g. "back", "next",
+"learn more", breadcrumb chevrons) so they point along the reading direction.
+Do **not** mirror:
+
+- direction-neutral icons (`search`, `settings`, `shield`, `plus`, …)
+- icons that already show both directions (`arrows-left-right`, `chevrons-left-right`)
+- chart/data indicators (`arrow-up-right` in a trend chart stays as drawn)
+
+`RtlAwareIcon` only mirrors when `directional` is set (or the `name` is a known
+directional icon); the default is no mirroring.
+
+### How to add a new RTL locale
+
+1. Add the locale code to `RTL_LOCALES` in all three places
+   (`src/i18n/config.js`, `component-library/src/i18n/config.ts`,
+   `frontend/lib/i18n/rtl.ts`).
+2. Add translation files under `locales/<code>/common.json` and register the
+   locale in the supported-languages lists.
+3. No other layout code needs to change — direction is derived from the
+   constant automatically.
+
+### Accessibility considerations
+
+- The `<html dir>` attribute is set from the active locale so screen readers
+  and browsers apply correct bidirectional text handling.
+- ARIA attributes that are **not** direction-dependent (`aria-label`,
+  `aria-labelledby`, `aria-describedby`, `aria-required`, `aria-invalid`,
+  `aria-live`, `aria-modal`) must **not** be swapped for RTL — only visual
+  layout and directional icons change. `A11yPrimitives.tsx` documents this and
+  uses logical CSS properties (`ms-*`, `start-*`) for spacing/positioning.
+- Use `getDirectionalValue(direction, ltrValue, rtlValue)` from
+  `A11yPrimitives.tsx` only when a value is genuinely direction-sensitive.
+
+### How to test RTL layouts
+
+- Unit tests: `RTL_LOCALES`, `isRTL`, `getTextDirection` (root, frontend and
+  component-library suites).
+- Hook test: `frontend/__tests__/useTextDirection.test.tsx`.
+- Layout test: `frontend/__tests__/layout-dir.test.tsx` asserts `<html dir>`
+  for `ar`, `he` and LTR locales.
+- Component tests: `component-library/src/components/RtlContainer.test.tsx`,
+  `RtlAwareIcon.test.tsx` and `frontend/__tests__/rtl-layout.test.tsx` verify
+  RTL/LTR layout behaviour and icon mirroring.
+- Tailwind/CSS tests: `frontend/__tests__/tailwind-rtl-variant.test.ts` and
+  `frontend/__tests__/rtl-css.test.ts` verify the `rtl:` variant and the
+  compiled RTL utilities.
+- Visual check: set the `NEXT_LOCALE` cookie to `ar` or `he` and confirm the
+  sidebar/navigation sits on the inline-end, form labels align to the start,
+  and directional arrows point correctly; confirm `en`/`es` are unchanged.
+
 ## Adding New Languages
 
 To add a new language:
@@ -216,11 +387,11 @@ supportedLngs: ['en', 'es', 'ar', 'fr']
 ```
 
 4. **Add RTL Support (if needed)**
-If the new language is RTL, add it to the RTL languages list:
+If the new language is RTL, add it to the `RTL_LOCALES` constant (see above):
 
 ```javascript
 // component-library/src/i18n/config.ts
-const rtlLanguages = ['ar', 'he', 'fa', 'ur', 'fr']; // if French was RTL
+export const RTL_LOCALES = ['ar', 'he', 'fa', 'ur', 'fr']; // if French was RTL
 ```
 
 ## Testing

--- a/component-library/package-lock.json
+++ b/component-library/package-lock.json
@@ -24,6 +24,8 @@
         "eslint": "^8.45.0",
         "eslint-plugin-react": "^7.32.0",
         "eslint-plugin-react-hooks": "^4.6.0",
+        "i18next-browser-languagedetector": "^7.1.0",
+        "i18next-fs-backend": "^2.1.1",
         "jest": "^29.6.0",
         "jest-environment-jsdom": "^30.4.1",
         "rollup": "^3.26.0",
@@ -5023,6 +5025,23 @@
       "dependencies": {
         "@babel/runtime": "^7.23.2"
       }
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-7.2.2.tgz",
+      "integrity": "sha512-6b7r75uIJDWCcCflmbof+sJ94k9UQO4X0YR62oUfqGI/GjCLVzlCwu8TFdRZIqVLzWbzNcmkmhfqKEr4TLz4HQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
+    "node_modules/i18next-fs-backend": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/i18next-fs-backend/-/i18next-fs-backend-2.6.7.tgz",
+      "integrity": "sha512-nN2TIycyR/d+OVuLm1ugPyOlMprqPRnQ7QktBgn44F3H8l7TeTH4ffHJ7nUsd4QVJfetWW7/VZ3s+4g7FoAZUA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",

--- a/component-library/package.json
+++ b/component-library/package.json
@@ -42,6 +42,8 @@
     "@rollup/plugin-node-resolve": "^15.1.0",
     "@rollup/plugin-typescript": "^11.1.0",
     "@types/jest": "^29.5.0",
+    "i18next-browser-languagedetector": "^7.1.0",
+    "i18next-fs-backend": "^2.1.1",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@typescript-eslint/eslint-plugin": "^6.0.0",

--- a/component-library/src/components/DirectionContext.ts
+++ b/component-library/src/components/DirectionContext.ts
@@ -1,0 +1,14 @@
+'use client';
+
+// component-library/src/components/DirectionContext.ts
+//
+// React context that lets RTL-aware components inherit the text direction
+// from an enclosing RtlContainer. Resolution order for a component:
+//   1. explicit `dir` prop
+//   2. nearest RtlContainer ancestor (via this context)
+//   3. the document direction (<html dir>)
+
+import React from 'react';
+import type { TextDirection } from '../utils/direction';
+
+export const DirectionContext = React.createContext<TextDirection | undefined>(undefined);

--- a/component-library/src/components/RtlAwareIcon.test.tsx
+++ b/component-library/src/components/RtlAwareIcon.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { RtlContainer } from './RtlContainer';
+import { RtlAwareIcon, isDirectionalIconName, DIRECTIONAL_ICON_NAMES } from './RtlAwareIcon';
+
+const Arrow = () => <svg data-testid="arrow" />;
+
+describe('RtlAwareIcon', () => {
+  it('mirrors directional icons in RTL', () => {
+    const html = renderToStaticMarkup(<RtlAwareIcon directional dir="rtl" icon={<Arrow />} />);
+    expect(html).toContain('transform:scaleX(-1)');
+  });
+
+  it('does not mirror directional icons in LTR', () => {
+    const html = renderToStaticMarkup(<RtlAwareIcon directional dir="ltr" icon={<Arrow />} />);
+    expect(html).not.toContain('scaleX(-1)');
+  });
+
+  it('does not mirror non-directional icons in RTL', () => {
+    const html = renderToStaticMarkup(<RtlAwareIcon dir="rtl" icon={<Arrow />} />);
+    expect(html).not.toContain('scaleX(-1)');
+  });
+
+  it('auto-detects directional icons by name in RTL', () => {
+    const html = renderToStaticMarkup(
+      <RtlAwareIcon name="chevron-right" dir="rtl" icon={<Arrow />} />
+    );
+    expect(html).toContain('transform:scaleX(-1)');
+  });
+
+  it('does not mirror direction-neutral icons by name in RTL', () => {
+    const html = renderToStaticMarkup(<RtlAwareIcon name="search" dir="rtl" icon={<Arrow />} />);
+    expect(html).not.toContain('scaleX(-1)');
+  });
+
+  it('inherits direction from an enclosing RtlContainer', () => {
+    const html = renderToStaticMarkup(
+      <RtlContainer dir="rtl">
+        <RtlAwareIcon directional icon={<Arrow />} />
+      </RtlContainer>
+    );
+    expect(html).toContain('transform:scaleX(-1)');
+  });
+
+  it('renders the icon content unchanged', () => {
+    const html = renderToStaticMarkup(<RtlAwareIcon dir="ltr" icon={<Arrow />} />);
+    expect(html).toContain('data-testid="arrow"');
+  });
+
+  it('exposes directional icon helpers', () => {
+    expect(isDirectionalIconName('arrow-left')).toBe(true);
+    expect(isDirectionalIconName('chevron-right')).toBe(true);
+    expect(isDirectionalIconName('search')).toBe(false);
+    expect(DIRECTIONAL_ICON_NAMES).toContain('arrow-right');
+  });
+});

--- a/component-library/src/components/RtlAwareIcon.tsx
+++ b/component-library/src/components/RtlAwareIcon.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+// component-library/src/components/RtlAwareIcon.tsx
+//
+// RTL-aware icon wrapper. Directional icons (arrows, chevrons, navigation
+// indicators) are mirrored with `transform: scaleX(-1)` in RTL; all other
+// icons render untouched. The wrapper is opt-in — icons are never mirrored
+// unless marked directional (explicitly or by a known directional name).
+
+import React, { useContext, useEffect, useState } from 'react';
+import { getDocumentDirection } from '../utils/direction';
+import type { TextDirection } from '../utils/direction';
+import { DirectionContext } from './DirectionContext';
+
+/**
+ * Directional icon names that should mirror in RTL (arrows, chevrons,
+ * navigation indicators). Icons not listed here are direction-neutral and
+ * must NOT be mirrored.
+ */
+export const DIRECTIONAL_ICON_NAMES = [
+  'arrow-down-left',
+  'arrow-down-right',
+  'arrow-left',
+  'arrow-right',
+  'arrow-up-left',
+  'arrow-up-right',
+  'chevron-down',
+  'chevron-left',
+  'chevron-right',
+  'chevron-up',
+  'chevrons-down',
+  'chevrons-left',
+  'chevrons-right',
+  'chevrons-up',
+  'corner-down-left',
+  'corner-down-right',
+  'corner-up-left',
+  'corner-up-right',
+  'move-left',
+  'move-right',
+  'redo',
+  'redo-2',
+  'undo',
+  'undo-2',
+] as const;
+
+export type DirectionalIconName = (typeof DIRECTIONAL_ICON_NAMES)[number];
+
+/** Returns `true` when the icon name is a directional icon. */
+export function isDirectionalIconName(name: string): boolean {
+  return (DIRECTIONAL_ICON_NAMES as readonly string[]).includes(name);
+}
+
+export interface RtlAwareIconProps extends React.HTMLAttributes<HTMLSpanElement> {
+  /** The icon to render (any React node — SVG, lucide icon, emoji, …). */
+  icon: React.ReactNode;
+  /** Optional icon name used to auto-detect directional icons. */
+  name?: string;
+  /** Explicitly mirror this icon in RTL; overrides `name` detection. */
+  directional?: boolean;
+  /**
+   * Explicit direction. When omitted, inherits from the document direction
+   * (`<html dir>`), which the app sets from the active locale.
+   */
+  dir?: TextDirection;
+}
+
+export function RtlAwareIcon({
+  icon,
+  name,
+  directional,
+  dir,
+  style,
+  className,
+  ...rest
+}: RtlAwareIconProps) {
+  const parentDir = useContext(DirectionContext);
+
+  // Initialise to 'ltr' on both server and client so the first client render
+  // matches the server render; the document direction is picked up after
+  // hydration to avoid hydration mismatches in Next.js.
+  const [documentDir, setDocumentDir] = useState<TextDirection>('ltr');
+
+  useEffect(() => {
+    if (dir === undefined && parentDir === undefined) {
+      setDocumentDir(getDocumentDirection());
+    }
+  }, [dir, parentDir]);
+
+  const resolvedDir = dir ?? parentDir ?? documentDir;
+  const isDirectional = directional ?? (name ? isDirectionalIconName(name) : false);
+  const shouldMirror = isDirectional && resolvedDir === 'rtl';
+
+  return (
+    <span
+      // Keep the glyph order stable; mirroring is done with a transform only.
+      dir="ltr"
+      className={className}
+      style={{
+        display: 'inline-block',
+        ...(shouldMirror ? { transform: 'scaleX(-1)' } : null),
+        ...style,
+      }}
+      {...rest}
+    >
+      {icon}
+    </span>
+  );
+}
+
+export default RtlAwareIcon;

--- a/component-library/src/components/RtlContainer.test.tsx
+++ b/component-library/src/components/RtlContainer.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { RtlContainer } from './RtlContainer';
+
+describe('RtlContainer', () => {
+  it('applies dir="rtl" for RTL', () => {
+    const html = renderToStaticMarkup(<RtlContainer dir="rtl">content</RtlContainer>);
+    expect(html).toContain('dir="rtl"');
+    expect(html).toContain('content');
+  });
+
+  it('applies dir="ltr" for LTR', () => {
+    const html = renderToStaticMarkup(<RtlContainer dir="ltr">content</RtlContainer>);
+    expect(html).toContain('dir="ltr"');
+  });
+
+  it('defaults to ltr when no direction is available (SSR / node)', () => {
+    const html = renderToStaticMarkup(<RtlContainer>content</RtlContainer>);
+    expect(html).toContain('dir="ltr"');
+  });
+
+  it('swaps flex direction when reverse is set in RTL', () => {
+    const html = renderToStaticMarkup(
+      <RtlContainer dir="rtl" reverse style={{ display: 'flex' }}>
+        content
+      </RtlContainer>
+    );
+    expect(html).toContain('flex-direction:row-reverse');
+  });
+
+  it('does not swap flex direction in LTR when reverse is set', () => {
+    const html = renderToStaticMarkup(
+      <RtlContainer dir="ltr" reverse>
+        content
+      </RtlContainer>
+    );
+    expect(html).not.toContain('flex-direction');
+  });
+
+  it('is direction-neutral by default (no forced RTL behaviour)', () => {
+    const html = renderToStaticMarkup(<RtlContainer dir="ltr">content</RtlContainer>);
+    expect(html).not.toContain('flex-direction');
+  });
+
+  it('preserves semantics when rendering as another element', () => {
+    const html = renderToStaticMarkup(
+      <RtlContainer as="section" dir="rtl" aria-label="section">
+        content
+      </RtlContainer>
+    );
+    expect(html).toContain('<section dir="rtl"');
+  });
+});

--- a/component-library/src/components/RtlContainer.tsx
+++ b/component-library/src/components/RtlContainer.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+// component-library/src/components/RtlContainer.tsx
+//
+// RTL-aware layout wrapper. Applies the active text direction to its subtree
+// and optionally swaps the flex row direction for RTL. Direction-neutral by
+// default — nothing is forced unless a prop asks for it.
+
+import React, { useContext, useEffect, useState } from 'react';
+import { getDocumentDirection } from '../utils/direction';
+import type { TextDirection } from '../utils/direction';
+import { DirectionContext } from './DirectionContext';
+
+export interface RtlContainerProps extends React.HTMLAttributes<HTMLElement> {
+  /** Render as this element (defaults to `<div>`) — preserve semantics. */
+  as?: React.ElementType;
+  /** Swap the flex row direction when RTL (`flex-direction: row-reverse`). */
+  reverse?: boolean;
+  /**
+   * Explicit direction. When omitted, inherits from the document direction
+   * (`<html dir>`), which the app sets from the active locale.
+   */
+  dir?: TextDirection;
+  children?: React.ReactNode;
+}
+
+export function RtlContainer({
+  as: Tag = 'div',
+  reverse = false,
+  dir,
+  style,
+  children,
+  ...rest
+}: RtlContainerProps) {
+  const parentDir = useContext(DirectionContext);
+
+  // Initialise to 'ltr' on both server and client so the first client render
+  // matches the server render; the document direction is picked up after
+  // hydration to avoid hydration mismatches in Next.js.
+  const [documentDir, setDocumentDir] = useState<TextDirection>('ltr');
+
+  useEffect(() => {
+    if (dir === undefined && parentDir === undefined) {
+      setDocumentDir(getDocumentDirection());
+    }
+  }, [dir, parentDir]);
+
+  const resolvedDir = dir ?? parentDir ?? documentDir;
+  const isRTL = resolvedDir === 'rtl';
+
+  return (
+    <DirectionContext.Provider value={resolvedDir}>
+      <Tag
+        dir={resolvedDir}
+        style={{
+          // flex rows follow the writing direction automatically; `reverse`
+          // opts into the opposite order for RTL when the layout requires it.
+          ...(reverse && isRTL ? { flexDirection: 'row-reverse' } : null),
+          ...style,
+        }}
+        {...(rest as React.HTMLAttributes<HTMLElement>)}
+      >
+        {children}
+      </Tag>
+    </DirectionContext.Provider>
+  );
+}
+
+export default RtlContainer;

--- a/component-library/src/components/index.ts
+++ b/component-library/src/components/index.ts
@@ -4,6 +4,8 @@ export { ResponsiveContainer } from './ResponsiveContainer';
 export { ResponsiveGrid } from './ResponsiveGrid';
 export { default as Modal } from './Modal';
 export { default as Dialog } from './Dialog';
+export { RtlContainer } from './RtlContainer';
+export { RtlAwareIcon, isDirectionalIconName, DIRECTIONAL_ICON_NAMES } from './RtlAwareIcon';
 
 export type { DraggableListProps } from './DraggableList';
 export type { LazyImageProps } from './LazyImage';
@@ -11,3 +13,5 @@ export type { ResponsiveContainerProps } from './ResponsiveContainer';
 export type { ResponsiveGridProps } from './ResponsiveGrid';
 export type { ModalProps } from './Modal';
 export type { DialogProps } from './Dialog';
+export type { RtlContainerProps } from './RtlContainer';
+export type { RtlAwareIconProps, DirectionalIconName } from './RtlAwareIcon';

--- a/component-library/src/i18n/config.ts
+++ b/component-library/src/i18n/config.ts
@@ -8,12 +8,34 @@ import enTranslations from '../../../locales/en/common.json';
 import esTranslations from '../../../locales/es/common.json';
 import arTranslations from '../../../locales/ar/common.json';
 
-// Supported languages
+/**
+ * Right-to-left (RTL) locales — the single authoritative source of text
+ * direction for this package. Arabic (`ar`) and Hebrew (`he`) resolve to
+ * RTL; add new RTL locales here and `supportedLanguages`, `isRTL` and
+ * `getTextDirection` pick them up automatically.
+ */
+export const RTL_LOCALES = ['ar', 'he', 'fa', 'ur'] as const;
+
+export type RtlLocale = (typeof RTL_LOCALES)[number];
+
+export type TextDirection = 'rtl' | 'ltr';
+
+// Utility functions
+export const isRTL = (language: string): boolean => {
+  return RTL_LOCALES.includes(language as RtlLocale);
+};
+
+export const getTextDirection = (language: string): TextDirection => {
+  return isRTL(language) ? 'rtl' : 'ltr';
+};
+
+// Supported languages. Direction is derived from `RTL_LOCALES` so the RTL
+// list stays the single source of truth.
 export const supportedLanguages = [
-  { code: 'en', name: 'English', dir: 'ltr' },
-  { code: 'es', name: 'Español', dir: 'ltr' },
-  { code: 'ar', name: 'العربية', dir: 'rtl' }
-];
+  { code: 'en', name: 'English' },
+  { code: 'es', name: 'Español' },
+  { code: 'ar', name: 'العربية' }
+].map(lang => ({ ...lang, dir: getTextDirection(lang.code) }));
 
 // Resources object
 const resources = {
@@ -87,16 +109,6 @@ i18n
   .init(i18nConfig);
 
 export default i18n;
-
-// Utility functions
-export const isRTL = (language: string): boolean => {
-  const lang = supportedLanguages.find(l => l.code === language);
-  return lang?.dir === 'rtl' || false;
-};
-
-export const getTextDirection = (language: string): 'rtl' | 'ltr' => {
-  return isRTL(language) ? 'rtl' : 'ltr';
-};
 
 export const formatCurrency = (
   amount: number, 

--- a/component-library/src/i18n/rtl.test.ts
+++ b/component-library/src/i18n/rtl.test.ts
@@ -1,0 +1,37 @@
+import { RTL_LOCALES, isRTL, getTextDirection, supportedLanguages } from './config';
+
+describe('RTL locale configuration (component-library)', () => {
+  it('exposes the authoritative RTL_LOCALES constant including ar and he', () => {
+    expect(RTL_LOCALES).toEqual(expect.arrayContaining(['ar', 'he']));
+  });
+
+  it('resolves Arabic to RTL', () => {
+    expect(isRTL('ar')).toBe(true);
+    expect(getTextDirection('ar')).toBe('rtl');
+  });
+
+  it('resolves Hebrew to RTL', () => {
+    expect(isRTL('he')).toBe(true);
+    expect(getTextDirection('he')).toBe('rtl');
+  });
+
+  it('resolves LTR locales to ltr', () => {
+    expect(isRTL('en')).toBe(false);
+    expect(getTextDirection('en')).toBe('ltr');
+    expect(isRTL('es')).toBe(false);
+    expect(getTextDirection('es')).toBe('ltr');
+  });
+
+  it('allows additional RTL locales without duplicating locale logic', () => {
+    // fa/ur are already listed; adding a new entry to RTL_LOCALES is enough
+    expect(isRTL('fa')).toBe(true);
+    expect(isRTL('ur')).toBe(true);
+  });
+
+  it('derives supportedLanguages direction from RTL_LOCALES', () => {
+    const ar = supportedLanguages.find(l => l.code === 'ar');
+    const en = supportedLanguages.find(l => l.code === 'en');
+    expect(ar?.dir).toBe('rtl');
+    expect(en?.dir).toBe('ltr');
+  });
+});

--- a/component-library/src/setupTests.ts
+++ b/component-library/src/setupTests.ts
@@ -1,1 +1,10 @@
 import '@testing-library/jest-dom';
+
+// jest-environment-jsdom 30 does not expose TextEncoder/TextDecoder, which
+// react-dom/server needs when rendering components to markup in tests.
+if (typeof globalThis.TextEncoder === 'undefined') {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { TextEncoder, TextDecoder } = require('util');
+  globalThis.TextEncoder = TextEncoder;
+  globalThis.TextDecoder = TextDecoder;
+}

--- a/component-library/src/utils/direction.ts
+++ b/component-library/src/utils/direction.ts
@@ -1,0 +1,19 @@
+// component-library/src/utils/direction.ts
+//
+// Shared text-direction helpers for RTL-aware components. These do NOT
+// depend on the i18n config so they can be used by layout primitives
+// without pulling i18next into the bundle.
+
+export type TextDirection = 'ltr' | 'rtl';
+
+/**
+ * Resolve the current document text direction from the `dir` attribute on
+ * `<html>` (set by the app for the active locale). Falls back to `'ltr'`
+ * when no document is available (SSR, tests) or no direction is set.
+ */
+export function getDocumentDirection(): TextDirection {
+  if (typeof document !== 'undefined' && document.documentElement) {
+    return document.documentElement.dir === 'rtl' ? 'rtl' : 'ltr';
+  }
+  return 'ltr';
+}

--- a/component-library/src/utils/index.ts
+++ b/component-library/src/utils/index.ts
@@ -1,3 +1,5 @@
 export { cache } from './cache';
 export { breakpoints, mediaQuery, MIN_TOUCH_TARGET, spacing } from './breakpoints';
+export { getDocumentDirection } from './direction';
 export type { Breakpoint } from './breakpoints';
+export type { TextDirection } from './direction';

--- a/frontend/__tests__/i18n-rtl.test.ts
+++ b/frontend/__tests__/i18n-rtl.test.ts
@@ -1,0 +1,40 @@
+import {
+  RTL_LOCALES,
+  DEFAULT_LOCALE,
+  LOCALE_COOKIE_NAME,
+  isRTL,
+  getTextDirection,
+} from '@/lib/i18n/rtl';
+
+describe('frontend RTL locale configuration (lib/i18n/rtl)', () => {
+  it('exposes the authoritative RTL_LOCALES constant including ar and he', () => {
+    expect(RTL_LOCALES).toEqual(expect.arrayContaining(['ar', 'he']));
+  });
+
+  it('resolves Arabic to rtl', () => {
+    expect(isRTL('ar')).toBe(true);
+    expect(getTextDirection('ar')).toBe('rtl');
+  });
+
+  it('resolves Hebrew to rtl', () => {
+    expect(isRTL('he')).toBe(true);
+    expect(getTextDirection('he')).toBe('rtl');
+  });
+
+  it('resolves LTR locales to ltr', () => {
+    expect(isRTL('en')).toBe(false);
+    expect(getTextDirection('en')).toBe('ltr');
+    expect(isRTL('es')).toBe(false);
+    expect(getTextDirection('es')).toBe('ltr');
+  });
+
+  it('defaults to en with a stable cookie name', () => {
+    expect(DEFAULT_LOCALE).toBe('en');
+    expect(LOCALE_COOKIE_NAME).toBe('NEXT_LOCALE');
+  });
+
+  it('supports additional RTL locales via the single constant', () => {
+    expect(getTextDirection('fa')).toBe('rtl');
+    expect(getTextDirection('ur')).toBe('rtl');
+  });
+});

--- a/frontend/__tests__/layout-dir.test.tsx
+++ b/frontend/__tests__/layout-dir.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import RootLayout from '@/app/layout';
+
+// The locale cookie is the single input that drives <html lang dir>.
+// jest.setup.js already mocks next/headers for `headers()`; here we override
+// the module with a controllable `cookies()` for the layout tests.
+let mockLocale: string | undefined;
+
+jest.mock('next/headers', () => ({
+  headers: () => ({ get: jest.fn(() => 'test-nonce-123456') }),
+  cookies: () => ({
+    get: jest.fn((name: string) => (mockLocale ? { name, value: mockLocale } : undefined)),
+  }),
+}));
+
+describe('RootLayout document direction', () => {
+  afterEach(() => {
+    mockLocale = undefined;
+  });
+
+  const renderLayout = () =>
+    render(
+      <RootLayout>
+        <div>page content</div>
+      </RootLayout>
+    );
+
+  it('renders <html dir="rtl" lang="ar"> for Arabic', () => {
+    mockLocale = 'ar';
+    const { container } = renderLayout();
+    const html = container.querySelector('html');
+    expect(html?.getAttribute('dir')).toBe('rtl');
+    expect(html?.getAttribute('lang')).toBe('ar');
+  });
+
+  it('renders <html dir="rtl" lang="he"> for Hebrew', () => {
+    mockLocale = 'he';
+    const { container } = renderLayout();
+    const html = container.querySelector('html');
+    expect(html?.getAttribute('dir')).toBe('rtl');
+    expect(html?.getAttribute('lang')).toBe('he');
+  });
+
+  it('renders <html dir="ltr" lang="es"> for an LTR locale', () => {
+    mockLocale = 'es';
+    const { container } = renderLayout();
+    const html = container.querySelector('html');
+    expect(html?.getAttribute('dir')).toBe('ltr');
+    expect(html?.getAttribute('lang')).toBe('es');
+  });
+
+  it('renders <html dir="ltr" lang="en"> when no locale cookie is set', () => {
+    mockLocale = undefined;
+    const { container } = renderLayout();
+    const html = container.querySelector('html');
+    expect(html?.getAttribute('dir')).toBe('ltr');
+    expect(html?.getAttribute('lang')).toBe('en');
+  });
+});

--- a/frontend/__tests__/rtl-css.test.ts
+++ b/frontend/__tests__/rtl-css.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+// The frontend ships its own compiled CSS (app/globals.css) rather than a
+// Tailwind build step, so the RTL utilities must be present there to be
+// available to the production build.
+const globalsCss = readFileSync(resolve(__dirname, '../app/globals.css'), 'utf8');
+
+// Normalise whitespace and quote style so the assertions survive prettier
+// reformatting (single vs double quotes, one-line vs multi-line rules).
+const normalize = (css: string): string => css.replace(/\s+/g, ' ').replace(/"/g, "'").trim();
+
+const css = normalize(globalsCss);
+
+describe('Frontend RTL CSS (app/globals.css)', () => {
+  it('defines logical text alignment for RTL', () => {
+    expect(css).toContain("[dir='rtl'] .text-start { text-align: right; }");
+    expect(css).toContain("[dir='rtl'] .text-end { text-align: left; }");
+  });
+
+  it('defines logical margin utilities for RTL', () => {
+    expect(css).toContain("[dir='rtl'] .ms-1");
+    expect(css).toContain("[dir='rtl'] .me-2");
+  });
+
+  it('defines logical padding utilities for RTL', () => {
+    expect(css).toContain("[dir='rtl'] .ps-3");
+    expect(css).toContain("[dir='rtl'] .pe-4");
+  });
+
+  it('swaps horizontal space utilities in RTL', () => {
+    expect(css).toContain("[dir='rtl'] .space-x-4 > * + *");
+  });
+
+  it('keeps LTR behaviour unchanged (base utilities stay physical)', () => {
+    expect(css).toContain('.text-start { text-align: left; }');
+    expect(css).toContain('.ms-1 { margin-left: 0.25rem; }');
+  });
+});

--- a/frontend/__tests__/rtl-layout.test.tsx
+++ b/frontend/__tests__/rtl-layout.test.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { RtlContainer, RtlAwareIcon } from '@soroban-scanner/ui-components';
+import {
+  getDirectionalValue,
+  StatusBadge,
+  SkipLink,
+} from '@/components/accessibility/A11yPrimitives';
+
+// ── RTL vs LTR layout behaviour (component-level visual verification) ────────
+
+describe('RTL layout behaviour', () => {
+  it('renders an RTL app shell with dir="rtl" and mirrored directional icons', () => {
+    const { container } = render(
+      <RtlContainer dir="rtl" className="app-shell">
+        {/* Header navigation flows right-to-left automatically under dir="rtl" */}
+        <nav aria-label="Primary" className="nav">
+          <RtlAwareIcon directional name="chevron-right" icon={<span>›</span>} />
+          <span>Menu item</span>
+        </nav>
+      </RtlContainer>
+    );
+
+    const shell = container.querySelector('.app-shell');
+    expect(shell?.getAttribute('dir')).toBe('rtl');
+
+    // Directional icon is mirrored
+    expect(container.innerHTML).toContain('scaleX(-1)');
+
+    // Icon glyph order is kept stable via the inner dir="ltr" wrapper
+    const iconWrapper = container.querySelector('span[dir="ltr"]');
+    expect(iconWrapper).not.toBeNull();
+  });
+
+  it('does not mirror non-directional icons in RTL', () => {
+    const { container } = render(
+      <RtlContainer dir="rtl" className="app-shell">
+        <RtlAwareIcon name="search" icon={<span>🔍</span>} />
+      </RtlContainer>
+    );
+    expect(container.innerHTML).not.toContain('scaleX(-1)');
+  });
+
+  it('preserves LTR layouts exactly (no mirroring, dir="ltr")', () => {
+    const { container } = render(
+      <RtlContainer dir="ltr" className="app-shell">
+        <nav aria-label="Primary" className="nav">
+          <RtlAwareIcon directional name="chevron-right" icon={<span>›</span>} />
+          <span>Menu item</span>
+        </nav>
+      </RtlContainer>
+    );
+
+    const shell = container.querySelector('.app-shell');
+    expect(shell?.getAttribute('dir')).toBe('ltr');
+    expect(container.innerHTML).not.toContain('scaleX(-1)');
+  });
+
+  it('keeps form labels direction-aware via logical alignment classes', () => {
+    const { container } = render(
+      <RtlContainer dir="rtl" className="app-shell">
+        <form>
+          <label className="text-start" htmlFor="scan-input">
+            Contract address
+          </label>
+          <input id="scan-input" type="text" />
+        </form>
+      </RtlContainer>
+    );
+    // In RTL, start = right: the label uses the logical text-start utility
+    expect(container.querySelector('label')?.className).toContain('text-start');
+    // The form inherits rtl from the container
+    expect(container.querySelector('form')?.closest('[dir="rtl"]')).not.toBeNull();
+  });
+
+  it('renders the same layout structure in LTR without RTL classes', () => {
+    const { container } = render(
+      <RtlContainer dir="ltr" className="app-shell">
+        <form>
+          <label className="text-start" htmlFor="scan-input">
+            Contract address
+          </label>
+          <input id="scan-input" type="text" />
+        </form>
+      </RtlContainer>
+    );
+    expect(container.querySelector('.app-shell')?.getAttribute('dir')).toBe('ltr');
+  });
+});
+
+// ── Direction-sensitive accessibility behaviour ──────────────────────────────
+
+describe('A11yPrimitives direction-sensitive behaviour', () => {
+  it('swaps direction-sensitive values with getDirectionalValue', () => {
+    expect(getDirectionalValue('ltr', 'left', 'right')).toBe('left');
+    expect(getDirectionalValue('rtl', 'left', 'right')).toBe('right');
+  });
+
+  it('keeps direction-neutral ARIA attributes identical in RTL (no blind swapping)', () => {
+    const { container } = render(
+      <RtlContainer dir="rtl">
+        <StatusBadge severity="high" count={3} />
+      </RtlContainer>
+    );
+    // aria-label is text, not a physical direction — must NOT be swapped
+    expect(container.querySelector('[aria-label]')?.getAttribute('aria-label')).toBe(
+      'High severity, 3 issues'
+    );
+    // Direction-sensitive spacing uses the logical ms-* utility
+    expect(container.querySelector('.ms-0\\.5')).not.toBeNull();
+  });
+
+  it('uses logical start positioning for the skip link', () => {
+    const { container } = render(<SkipLink />);
+    expect(container.querySelector('a')?.className).toContain('focus:start-4');
+  });
+});

--- a/frontend/__tests__/tailwind-rtl-variant.test.ts
+++ b/frontend/__tests__/tailwind-rtl-variant.test.ts
@@ -1,0 +1,43 @@
+import postcss from 'postcss';
+import tailwindcss from 'tailwindcss';
+
+// Load the a11y Tailwind config (contains the `rtl:` variant plugin)
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const a11yConfig = require('../tailwind.config.a11y.js');
+
+async function compileWith(content: string): Promise<string> {
+  const result = await postcss([
+    tailwindcss({
+      ...a11yConfig,
+      content: [{ raw: content, extension: 'html' }],
+    }),
+  ]).process('@tailwind utilities;', { from: undefined });
+  return result.css;
+}
+
+describe('Tailwind rtl: variant (tailwind.config.a11y.js)', () => {
+  it('generates [dir="rtl"]-scoped margin utilities', async () => {
+    const css = await compileWith('<div class="rtl:ml-4 rtl:mr-0"></div>');
+    expect(css).toContain('[dir="rtl"]');
+    expect(css).toContain('margin-left');
+    expect(css).toContain('margin-right');
+  });
+
+  it('generates [dir="rtl"]-scoped padding utilities', async () => {
+    const css = await compileWith('<div class="rtl:pr-3 rtl:pl-0"></div>');
+    expect(css).toContain('[dir="rtl"]');
+    expect(css).toContain('padding-right');
+  });
+
+  it('generates [dir="rtl"]-scoped text alignment', async () => {
+    const css = await compileWith('<div class="rtl:text-right"></div>');
+    expect(css).toContain('[dir="rtl"]');
+    expect(css).toContain('text-align: right');
+  });
+
+  it('generates [dir="rtl"]-scoped flex direction', async () => {
+    const css = await compileWith('<div class="rtl:flex-row-reverse"></div>');
+    expect(css).toContain('[dir="rtl"]');
+    expect(css).toContain('flex-direction: row-reverse');
+  });
+});

--- a/frontend/__tests__/useTextDirection.test.tsx
+++ b/frontend/__tests__/useTextDirection.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import { useTextDirection } from '@/hooks/useTextDirection';
+import { useLocaleStore } from '@/store/localeStore';
+
+function Probe() {
+  const direction = useTextDirection();
+  return <div data-testid="direction">{direction}</div>;
+}
+
+describe('useTextDirection', () => {
+  beforeEach(() => {
+    // Reset the store to its default state between tests
+    useLocaleStore.setState({ locale: 'en', direction: 'ltr' });
+  });
+
+  it('returns ltr by default', () => {
+    render(<Probe />);
+    expect(screen.getByTestId('direction')).toHaveTextContent('ltr');
+  });
+
+  it('returns rtl when the active locale is Arabic', () => {
+    render(<Probe />);
+    act(() => {
+      useLocaleStore.getState().setLocale('ar');
+    });
+    expect(screen.getByTestId('direction')).toHaveTextContent('rtl');
+  });
+
+  it('returns rtl when the active locale is Hebrew', () => {
+    render(<Probe />);
+    act(() => {
+      useLocaleStore.getState().setLocale('he');
+    });
+    expect(screen.getByTestId('direction')).toHaveTextContent('rtl');
+  });
+
+  it('returns ltr for an LTR locale (Spanish)', () => {
+    render(<Probe />);
+    act(() => {
+      useLocaleStore.getState().setLocale('es');
+    });
+    expect(screen.getByTestId('direction')).toHaveTextContent('ltr');
+  });
+
+  it('reacts to locale changes back to ltr', () => {
+    render(<Probe />);
+    act(() => {
+      useLocaleStore.getState().setLocale('ar');
+    });
+    expect(screen.getByTestId('direction')).toHaveTextContent('rtl');
+    act(() => {
+      useLocaleStore.getState().setLocale('en');
+    });
+    expect(screen.getByTestId('direction')).toHaveTextContent('ltr');
+  });
+
+  it('updates the document direction and lang when the locale changes', () => {
+    document.documentElement.dir = 'ltr';
+    document.documentElement.lang = 'en';
+    act(() => {
+      useLocaleStore.getState().setLocale('ar');
+    });
+    expect(document.documentElement.dir).toBe('rtl');
+    expect(document.documentElement.lang).toBe('ar');
+  });
+});

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -229,3 +229,64 @@ p {
 .toast-progress {
   animation: shrink linear forwards;
 }
+
+/* ── RTL (Right-to-Left) Support ─────────────────────────────────────────────
+   Logical-property utilities so spacing and alignment follow the active text
+   direction (the <html> element gets dir="rtl" for Arabic/Hebrew locales).
+   Everything below is scoped to [dir="rtl"] subtrees, so LTR layouts are
+   completely unaffected. These mirror the `rtl:` Tailwind variant behaviour
+   for the CSS-shim classes used across the frontend. */
+
+/* Logical text alignment */
+.text-start { text-align: left; }
+.text-end { text-align: right; }
+[dir="rtl"] .text-start { text-align: right; }
+[dir="rtl"] .text-end { text-align: left; }
+
+/* Logical margins (start/end = left/right in LTR, right/left in RTL) */
+.ms-0 { margin-left: 0; }
+.me-0 { margin-right: 0; }
+.ms-1 { margin-left: 0.25rem; }
+.me-1 { margin-right: 0.25rem; }
+.ms-2 { margin-left: 0.5rem; }
+.me-2 { margin-right: 0.5rem; }
+.ms-3 { margin-left: 1rem; }
+.me-3 { margin-right: 1rem; }
+.ms-4 { margin-left: 1.5rem; }
+.me-4 { margin-right: 1.5rem; }
+[dir="rtl"] .ms-0 { margin-left: 0; }
+[dir="rtl"] .ms-1 { margin-left: 0; margin-right: 0.25rem; }
+[dir="rtl"] .ms-2 { margin-left: 0; margin-right: 0.5rem; }
+[dir="rtl"] .ms-3 { margin-left: 0; margin-right: 1rem; }
+[dir="rtl"] .ms-4 { margin-left: 0; margin-right: 1.5rem; }
+[dir="rtl"] .me-0 { margin-right: 0; }
+[dir="rtl"] .me-1 { margin-right: 0; margin-left: 0.25rem; }
+[dir="rtl"] .me-2 { margin-right: 0; margin-left: 0.5rem; }
+[dir="rtl"] .me-3 { margin-right: 0; margin-left: 1rem; }
+[dir="rtl"] .me-4 { margin-right: 0; margin-left: 1.5rem; }
+
+/* Logical padding */
+.ps-1 { padding-left: 0.25rem; }
+.pe-1 { padding-right: 0.25rem; }
+.ps-2 { padding-left: 0.5rem; }
+.pe-2 { padding-right: 0.5rem; }
+.ps-3 { padding-left: 1rem; }
+.pe-3 { padding-right: 1rem; }
+.ps-4 { padding-left: 1.5rem; }
+.pe-4 { padding-right: 1.5rem; }
+[dir="rtl"] .ps-1 { padding-left: 0; padding-right: 0.25rem; }
+[dir="rtl"] .ps-2 { padding-left: 0; padding-right: 0.5rem; }
+[dir="rtl"] .ps-3 { padding-left: 0; padding-right: 1rem; }
+[dir="rtl"] .ps-4 { padding-left: 0; padding-right: 1.5rem; }
+[dir="rtl"] .pe-1 { padding-right: 0; padding-left: 0.25rem; }
+[dir="rtl"] .pe-2 { padding-right: 0; padding-left: 0.5rem; }
+[dir="rtl"] .pe-3 { padding-right: 0; padding-left: 1rem; }
+[dir="rtl"] .pe-4 { padding-right: 0; padding-left: 1.5rem; }
+
+/* Horizontal space utilities follow the direction (nav rows, button groups) */
+[dir="rtl"] .space-x-3 > * + * { margin-left: 0; margin-right: 0.75rem; }
+[dir="rtl"] .space-x-4 > * + * { margin-left: 0; margin-right: 1rem; }
+[dir="rtl"] .space-x-8 > * + * { margin-left: 0; margin-right: 2rem; }
+
+/* Flex rows follow the writing direction automatically (flex-direction: row
+   is direction-aware), so no overrides are needed for the common case. */

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,8 +1,10 @@
 import type { Metadata, Viewport } from 'next';
 import type { ReactNode } from 'react';
-import { headers } from 'next/headers';
+import { cookies, headers } from 'next/headers';
 import './globals.css';
 import { PageErrorBoundary } from '@/components/ui/ErrorBoundary';
+import { LocaleProvider } from '@/components/i18n/LocaleProvider';
+import { DEFAULT_LOCALE, LOCALE_COOKIE_NAME, getTextDirection } from '@/lib/i18n/rtl';
 import {
   getSiteUrl,
   siteDescription,
@@ -64,8 +66,15 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   const headersList = headers();
   const nonce = headersList.get('x-nonce') || '';
 
+  // Active locale comes from our own cookie (set by the locale store), never
+  // from browser heuristics, so the rendered direction is deterministic and
+  // identical on server and client.
+  const cookieStore = cookies();
+  const locale = cookieStore.get(LOCALE_COOKIE_NAME)?.value || DEFAULT_LOCALE;
+  const dir = getTextDirection(locale);
+
   return (
-    <html lang="en">
+    <html lang={locale} dir={dir}>
       <body>
         <script
           type="application/ld+json"
@@ -77,7 +86,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
             }).replace(/</g, '\\u003c'),
           }}
         />
-        <PageErrorBoundary>{children}</PageErrorBoundary>
+        <LocaleProvider locale={locale}>{children}</LocaleProvider>
       </body>
     </html>
   );

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -15,11 +15,13 @@ import {
   HelpCircle,
   ShieldCheck,
 } from 'lucide-react';
+import { RtlContainer } from '@soroban-scanner/ui-components';
 
 // Help components
 import HelpPanel from '../components/help/HelpPanel';
 import GuidedTour from '../components/help/GuidedTour';
 import { useHelpStore } from '../lib/store/helpStore';
+import { useTextDirection } from '@/hooks/useTextDirection';
 
 // Types
 type View =
@@ -149,6 +151,7 @@ const DisputeForm = ({ submission, onSubmitDispute, onCancel }: any) => (
 );
 
 export default function App() {
+  const direction = useTextDirection();
   const [activeTab, setActiveTab] = useState<View>('scanner');
   const [selectedBounty, setSelectedBounty] = useState<Bounty | null>(null);
   const [showReportForm, setShowReportForm] = useState(false);
@@ -283,7 +286,7 @@ export default function App() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <RtlContainer dir={direction} className="min-h-screen bg-gray-50">
       <header className="bg-white shadow-sm border-b">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center h-16">
@@ -374,6 +377,6 @@ export default function App() {
       {activeTab === 'scanner' && <GuidedTour tourId="scan" />}
       {activeTab === 'report' && <GuidedTour tourId="vulnerability" />}
       {activeTab === 'time-travel' && <GuidedTour tourId="time-travel" />}
-    </div>
+    </RtlContainer>
   );
 }

--- a/frontend/components/accessibility/A11yPrimitives.tsx
+++ b/frontend/components/accessibility/A11yPrimitives.tsx
@@ -4,6 +4,16 @@
 //
 // WCAG 2.1 AA-compliant primitive components for Soroban Security Scanner.
 // Each component documents which success criteria it satisfies.
+//
+// RTL (right-to-left) note:
+// The ARIA attributes used by these primitives (`aria-label`, `aria-labelledby`,
+// `aria-describedby`, `aria-required`, `aria-invalid`, `aria-live`, `aria-modal`,
+// `aria-hidden`) are NOT left/right direction-dependent — their values are
+// identifiers, states or text, never physical directions — so they must NOT be
+// swapped for RTL. Direction-sensitive behaviour is limited to CSS (logical
+// properties like `ms-*` / `start-*` below) and to visual content, which the
+// `dir="rtl"` attribute on <html> already handles. Use `getDirectionalValue`
+// when a value genuinely needs to differ per direction.
 
 import React, { useEffect, useRef } from 'react';
 import {
@@ -13,6 +23,17 @@ import {
   useSkipLink,
   useReducedMotion,
 } from '@/hooks/useAccessibility';
+
+// ── 0. Direction helper (RTL support) ────────────────────────────────────────
+/**
+ * Returns the direction-sensitive value for the active text direction.
+ * Use only for values whose meaning is genuinely physical (e.g. "left" /
+ * "right" words in an aria-label). Do NOT use it for direction-neutral ARIA
+ * attributes — those must stay identical in both directions.
+ */
+export function getDirectionalValue<T>(direction: 'ltr' | 'rtl', ltrValue: T, rtlValue: T): T {
+  return direction === 'rtl' ? rtlValue : ltrValue;
+}
 
 // ── 1. SkipLink (WCAG 2.4.1 – Bypass Blocks) ─────────────────────────────────
 /**
@@ -39,8 +60,9 @@ export function SkipLink({
       className={[
         // Visually hidden until focused
         'sr-only focus:not-sr-only',
-        // Visible styling when focused
-        'focus:fixed focus:top-4 focus:left-4 focus:z-[9999]',
+        // Visible styling when focused (start-4 = inline-start: left in LTR,
+        // right in RTL — logical, so the skip link lands on the reading side)
+        'focus:fixed focus:top-4 focus:start-4 focus:z-[9999]',
         'focus:rounded-lg focus:bg-cyan-400 focus:px-4 focus:py-2',
         'focus:text-sm focus:font-bold focus:text-gray-950',
         'focus:shadow-lg focus:outline-none',
@@ -216,7 +238,7 @@ export function AccessibleFormField({
         {required && (
           <>
             {/* Screen reader: "required" */}
-            <span aria-hidden="true" className="ml-1 text-cyan-400">
+            <span aria-hidden="true" className="ms-1 text-cyan-400">
               *
             </span>
             <span className="sr-only"> (required)</span>
@@ -345,7 +367,7 @@ export function StatusBadge({ severity, count }: { severity: Severity; count?: n
       <span aria-hidden="true">{cfg.icon}</span>
       {cfg.label}
       {count !== undefined && (
-        <span className="ml-0.5 rounded-full bg-black/30 px-1.5 py-px text-[10px]">{count}</span>
+        <span className="ms-0.5 rounded-full bg-black/30 px-1.5 py-px text-[10px]">{count}</span>
       )}
     </span>
   );

--- a/frontend/components/auth/MultiFactorAuth.tsx
+++ b/frontend/components/auth/MultiFactorAuth.tsx
@@ -11,6 +11,7 @@ import {
   Key,
   Clock,
 } from 'lucide-react';
+import { RtlAwareIcon } from '@soroban-scanner/ui-components';
 
 type MfaMethod = 'totp' | 'sms' | 'email';
 
@@ -192,7 +193,12 @@ export default function MultiFactorAuth({
           className="flex items-center text-gray-600 hover:text-gray-900 mb-6 transition-optimized"
           disabled={isLoading}
         >
-          <ArrowLeft className="h-4 w-4 mr-2" />
+          {/* Directional back arrow: points left in LTR, right (mirrored) in RTL */}
+          <RtlAwareIcon
+            directional
+            name="arrow-left"
+            icon={<ArrowLeft className="h-4 w-4 me-2" />}
+          />
           Back
         </button>
 

--- a/frontend/components/auth/PasswordResetForm.tsx
+++ b/frontend/components/auth/PasswordResetForm.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, FormEvent } from 'react';
 import { Mail, ArrowLeft, AlertCircle, CheckCircle, Send } from 'lucide-react';
+import { RtlAwareIcon } from '@soroban-scanner/ui-components';
 
 interface PasswordResetFormData {
   email: string;
@@ -128,7 +129,12 @@ export default function PasswordResetForm({
           className="flex items-center text-gray-600 hover:text-gray-900 mb-6 transition-optimized"
           disabled={isLoading}
         >
-          <ArrowLeft className="h-4 w-4 mr-2" />
+          {/* Directional back arrow: points left in LTR, right (mirrored) in RTL */}
+          <RtlAwareIcon
+            directional
+            name="arrow-left"
+            icon={<ArrowLeft className="h-4 w-4 me-2" />}
+          />
           Back to Login
         </button>
 

--- a/frontend/components/help/HelpPanel.tsx
+++ b/frontend/components/help/HelpPanel.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef } from 'react';
+import { RtlAwareIcon } from '@soroban-scanner/ui-components';
 import { HELP_CONTENT, HelpTopic } from '../../lib/help-content';
 
 interface HelpPanelProps {
@@ -47,8 +48,7 @@ const HelpPanel: React.FC<HelpPanelProps> = ({ topic, onClose }) => {
     >
       <div
         ref={panelRef}
-        className="w-full max-w-md h-full bg-white shadow-2xl p-0 overflow-y-auto transform transition-transform duration-300 ease-out translate-x-0"
-        style={{ animation: 'slideInRight 0.3s ease-out' }}
+        className="help-panel-drawer w-full max-w-md h-full bg-white shadow-2xl p-0 overflow-y-auto transform transition-transform duration-300 ease-out translate-x-0"
         onClick={e => e.stopPropagation()}
       >
         <div className="sticky top-0 bg-white/80 backdrop-blur-md border-b px-6 py-4 flex items-center justify-between z-10">
@@ -111,20 +111,27 @@ const HelpPanel: React.FC<HelpPanelProps> = ({ topic, onClose }) => {
               className="group flex items-center justify-between p-4 bg-blue-600 rounded-2xl text-white font-bold hover:bg-blue-700 transition-all shadow-lg shadow-blue-200"
             >
               <span>Learn more in our Docs</span>
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                className="h-5 w-5 transform group-hover:translate-x-1 transition-transform"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M14 5l7 7m0 0l-7 7m7-7H3"
-                />
-              </svg>
+              {/* Directional arrow: points right in LTR, left (mirrored) in RTL */}
+              <RtlAwareIcon
+                directional
+                name="arrow-right"
+                icon={
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="h-5 w-5 transform group-hover:translate-x-1 transition-transform"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M14 5l7 7m0 0l-7 7m7-7H3"
+                    />
+                  </svg>
+                }
+              />
             </a>
           </div>
         </div>
@@ -138,6 +145,22 @@ const HelpPanel: React.FC<HelpPanelProps> = ({ topic, onClose }) => {
           to {
             transform: translateX(0);
           }
+        }
+        @keyframes slideInLeft {
+          from {
+            transform: translateX(-100%);
+          }
+          to {
+            transform: translateX(0);
+          }
+        }
+        .help-panel-drawer {
+          animation: slideInRight 0.3s ease-out;
+        }
+        /* In RTL the drawer is anchored to the inline-end (left side), so it
+           slides in from the left instead of the right. */
+        [dir='rtl'] .help-panel-drawer {
+          animation: slideInLeft 0.3s ease-out;
         }
       `}</style>
     </div>

--- a/frontend/components/i18n/LocaleProvider.tsx
+++ b/frontend/components/i18n/LocaleProvider.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+// frontend/components/i18n/LocaleProvider.tsx
+//
+// Bridges the server-rendered locale (read from the NEXT_LOCALE cookie by
+// the root layout) into the client locale store.
+//
+// The store starts at DEFAULT_LOCALE on both server and client so the first
+// client render matches the server render — this effect runs only after
+// hydration, then flips the store to the persisted locale. That keeps the
+// client components that consume useTextDirection() in sync with the
+// `<html dir>` attribute set by the layout without hydration mismatches.
+
+import { useEffect } from 'react';
+import type { ReactNode } from 'react';
+import { useLocaleStore } from '@/store/localeStore';
+
+interface LocaleProviderProps {
+  /** Locale the server rendered with (from the NEXT_LOCALE cookie). */
+  locale: string;
+  children: ReactNode;
+}
+
+export function LocaleProvider({ locale, children }: LocaleProviderProps) {
+  useEffect(() => {
+    const { locale: current, setLocale } = useLocaleStore.getState();
+    if (current !== locale) {
+      setLocale(locale);
+    }
+  }, [locale]);
+
+  return <>{children}</>;
+}
+
+export default LocaleProvider;

--- a/frontend/hooks/useTextDirection.ts
+++ b/frontend/hooks/useTextDirection.ts
@@ -1,0 +1,21 @@
+'use client';
+
+// frontend/hooks/useTextDirection.ts
+//
+// Returns the text direction (`'ltr'` | `'rtl'`) of the active locale.
+// The direction is derived from the authoritative `RTL_LOCALES` definition
+// (lib/i18n/rtl.ts) via the locale store — never from browser heuristics.
+//
+// SSR note: the store initialises to `DEFAULT_LOCALE` on both server and
+// client, so the first client render matches the server render. The
+// LocaleProvider syncs the persisted locale after hydration, which flips
+// the direction without a hydration mismatch.
+
+import { useLocaleStore } from '@/store/localeStore';
+import type { TextDirection } from '@/lib/i18n/rtl';
+
+export function useTextDirection(): TextDirection {
+  return useLocaleStore(state => state.direction);
+}
+
+export default useTextDirection;

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -13,6 +13,12 @@ const customJestConfig = {
   moduleNameMapper: {
     // Handle module aliases (if you configured them in tsconfig.json)
     '^@/(.*)$': '<rootDir>/$1',
+    // Monorepo: the component-library ships its own react copy; unify React
+    // so components imported from '@soroban-scanner/ui-components' share the
+    // test runner's React instance (avoids "Cannot read properties of null
+    // (reading 'useState')" from duplicate React copies).
+    '^react$': '<rootDir>/node_modules/react',
+    '^react-dom$': '<rootDir>/node_modules/react-dom',
   },
   testMatch: ['**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[jt]s?(x)'],
   collectCoverageFrom: [

--- a/frontend/lib/i18n/rtl.ts
+++ b/frontend/lib/i18n/rtl.ts
@@ -1,0 +1,30 @@
+// frontend/lib/i18n/rtl.ts
+//
+// Single authoritative RTL locale definition for the frontend.
+// The <html> element direction, useTextDirection() and the locale store
+// all derive from these constants — no other module should hard-code
+// `ar`/`he` checks.
+
+/** Right-to-left (RTL) locales. Arabic and Hebrew are RTL; add new RTL
+ *  locales here and every consumer picks them up automatically. */
+export const RTL_LOCALES = ['ar', 'he', 'fa', 'ur'] as const;
+
+export type RtlLocale = (typeof RTL_LOCALES)[number];
+
+export type TextDirection = 'ltr' | 'rtl';
+
+/** Default locale used when no locale is stored/selected. */
+export const DEFAULT_LOCALE = 'en';
+
+/** Cookie used to persist the active locale for server-rendered HTML. */
+export const LOCALE_COOKIE_NAME = 'NEXT_LOCALE';
+
+/** Returns `true` when `locale` is a right-to-left locale. */
+export function isRTL(locale: string): boolean {
+  return RTL_LOCALES.includes(locale as RtlLocale);
+}
+
+/** Resolves the text direction for the given locale (not browser heuristics). */
+export function getTextDirection(locale: string): TextDirection {
+  return isRTL(locale) ? 'rtl' : 'ltr';
+}

--- a/frontend/store/localeStore.ts
+++ b/frontend/store/localeStore.ts
@@ -1,0 +1,45 @@
+'use client';
+
+// frontend/store/localeStore.ts
+//
+// Global locale state for the frontend.
+//
+// - The initial value is `DEFAULT_LOCALE` on BOTH server and client so the
+//   first client render matches the server render (no hydration mismatch).
+// - `setLocale()` persists the locale in a cookie (`NEXT_LOCALE`) so the
+//   server-rendered `<html lang dir>` stays in sync on the next request,
+//   and imperatively updates `document.documentElement.lang/dir` so the
+//   currently rendered page flips direction immediately.
+// - The LocaleProvider (see components/i18n/LocaleProvider) syncs the
+//   cookie value into this store after hydration.
+
+import { create } from 'zustand';
+import { DEFAULT_LOCALE, LOCALE_COOKIE_NAME, getTextDirection } from '@/lib/i18n/rtl';
+import type { TextDirection } from '@/lib/i18n/rtl';
+
+interface LocaleStore {
+  /** Active locale, e.g. `en`, `es`, `ar`, `he`. */
+  locale: string;
+  /** Text direction derived from the active locale. */
+  direction: TextDirection;
+  /** Set the active locale, persist it and update the document direction. */
+  setLocale: (locale: string) => void;
+}
+
+export const useLocaleStore = create<LocaleStore>()(set => ({
+  locale: DEFAULT_LOCALE,
+  direction: getTextDirection(DEFAULT_LOCALE),
+  setLocale: locale => {
+    const direction = getTextDirection(locale);
+
+    if (typeof document !== 'undefined') {
+      // Persist for server-rendered HTML on the next request.
+      document.cookie = `${LOCALE_COOKIE_NAME}=${encodeURIComponent(locale)};path=/;max-age=31536000;samesite=lax`;
+      // Flip the current page immediately.
+      document.documentElement.lang = locale;
+      document.documentElement.dir = direction;
+    }
+
+    set({ locale, direction });
+  },
+}));

--- a/frontend/tailwind.config.a11y.js
+++ b/frontend/tailwind.config.a11y.js
@@ -143,5 +143,13 @@ module.exports = {
         },
       });
     }),
+
+    // ── Plugin: `rtl:` variant (Right-to-Left support) ──────────────────────
+    // Enables direction-aware utilities such as `rtl:ml-4`, `rtl:text-right`,
+    // `rtl:flex-row-reverse`, `rtl:mr-0`, `rtl:pr-3`, etc. The selector matches
+    // any element inside a `[dir="rtl"]` subtree (e.g. <html dir="rtl">).
+    plugin(function ({ addVariant }) {
+      addVariant('rtl', '&:where([dir="rtl"], [dir="rtl"] *)');
+    }),
   ],
 };

--- a/src/i18n/config.js
+++ b/src/i18n/config.js
@@ -5,6 +5,14 @@ const enCommon = require('../../locales/en/common.json');
 const esCommon = require('../../locales/es/common.json');
 const arCommon = require('../../locales/ar/common.json');
 
+/**
+ * Right-to-left (RTL) locales — the single authoritative source of text
+ * direction for this package. Add new RTL locales here; `isRTL` and
+ * `getTextDirection` derive from this list, so no other place needs to
+ * know which locales are RTL.
+ */
+const RTL_LOCALES = ['ar', 'he', 'fa', 'ur'];
+
 const i18nConfig = {
   // Supported languages
   supportedLngs: ['en', 'es', 'ar'],
@@ -76,8 +84,7 @@ function t(key, options = {}) {
  * Check if language is RTL
  */
 function isRTL(language) {
-  const rtlLanguages = ['ar', 'he', 'fa', 'ur'];
-  return rtlLanguages.includes(language);
+  return RTL_LOCALES.includes(language);
 }
 
 /**
@@ -129,6 +136,7 @@ module.exports = {
   initializeI18n,
   t,
   i18nConfig,
+  RTL_LOCALES,
   isRTL,
   getTextDirection,
   formatCurrency,

--- a/tests/i18n-rtl.test.js
+++ b/tests/i18n-rtl.test.js
@@ -1,0 +1,41 @@
+// tests/i18n-rtl.test.js
+//
+// Tests for the authoritative RTL locale configuration in src/i18n/config.js.
+
+const { RTL_LOCALES, isRTL, getTextDirection } = require('../src/i18n/config');
+
+describe('RTL locale configuration (src/i18n/config.js)', () => {
+  it('exposes the authoritative RTL_LOCALES constant including ar and he', () => {
+    expect(Array.isArray(RTL_LOCALES)).toBe(true);
+    expect(RTL_LOCALES).toEqual(expect.arrayContaining(['ar', 'he']));
+  });
+
+  it('resolves Arabic to RTL', () => {
+    expect(isRTL('ar')).toBe(true);
+    expect(getTextDirection('ar')).toBe('rtl');
+  });
+
+  it('resolves Hebrew to RTL', () => {
+    expect(isRTL('he')).toBe(true);
+    expect(getTextDirection('he')).toBe('rtl');
+  });
+
+  it('resolves LTR locales to ltr', () => {
+    expect(isRTL('en')).toBe(false);
+    expect(getTextDirection('en')).toBe('ltr');
+    expect(isRTL('es')).toBe(false);
+    expect(getTextDirection('es')).toBe('ltr');
+  });
+
+  it('supports additional RTL locales via the single constant', () => {
+    // Adding a locale to RTL_LOCALES is sufficient — no other logic to update
+    expect(isRTL('fa')).toBe(true);
+    expect(isRTL('ur')).toBe(true);
+    expect(getTextDirection('fa')).toBe('rtl');
+  });
+
+  it('treats unknown locales as LTR', () => {
+    expect(isRTL('xx')).toBe(false);
+    expect(getTextDirection('xx')).toBe('ltr');
+  });
+});


### PR DESCRIPTION
## Summary

Implements full right-to-left (RTL) layout support for the frontend for Arabic (`ar`) and Hebrew (`he`), following the repository's existing i18n architecture. LTR locales (English, Spanish) are preserved exactly.

## RTL locale handling

A single authoritative `RTL_LOCALES` constant now exists in each package (`src/i18n/config.js`, `component-library/src/i18n/config.ts`, and the new `frontend/lib/i18n/rtl.ts`). `isRTL()` and `getTextDirection()` derive from it, so Arabic and Hebrew resolve to RTL and adding a new RTL locale is a one-line change — no duplicated locale logic.

## Dynamic HTML direction

`frontend/app/layout.tsx` reads the active locale from the `NEXT_LOCALE` cookie (never browser heuristics) and renders `<html lang={locale} dir={getTextDirection(locale)}>`:
- `ar` / `he` → `dir="rtl"`
- `en` / `es` / other LTR locales → `dir="ltr"`

A `LocaleProvider` syncs the server-rendered locale into the client locale store (zustand) after hydration, and the store flips `document.documentElement.dir` immediately on change — no hydration mismatches.

## Tailwind RTL support

`frontend/tailwind.config.a11y.js` registers an `rtl:` variant (`&:where([dir="rtl"], [dir="rtl"] *)`) enabling `rtl:ml-4`, `rtl:text-right`, `rtl:flex-row-reverse`, etc. Because the frontend ships its own compiled CSS, the equivalent logical utilities (`ms-*`, `me-*`, `ps-*`, `pe-*`, `text-start`/`text-end`, RTL `space-x-*` swaps) were also added to `app/globals.css`, scoped to `[dir="rtl"]` so LTR layouts are unaffected.

## useTextDirection()

New `frontend/hooks/useTextDirection.ts` returns `'ltr' | 'rtl'` from the active locale via the locale store, reusing the authoritative `RTL_LOCALES` definition and reacting to locale changes.

## RtlContainer

New `component-library/src/components/RtlContainer.tsx` — a reusable, direction-neutral layout wrapper that applies the text direction, optionally swaps flex direction for RTL, renders as any element, and exposes its direction to descendants via context.

## RtlAwareIcon

New `component-library/src/components/RtlAwareIcon.tsx` — mirrors directional icons (arrows, chevrons, navigation indicators) with `transform: scaleX(-1)` in RTL only. Non-directional icons are never mirrored. Integrated into the app shell, the help drawer ("Learn more" arrow) and the auth back buttons.

## Accessibility updates

`A11yPrimitives.tsx` now uses logical spacing/positioning (`ms-*`, `start-*`) and documents that the ARIA attributes it uses are direction-neutral and must not be blindly swapped. A `getDirectionalValue()` helper is provided for genuinely direction-sensitive values. WCAG behaviour is preserved.

## Visual / test coverage

Component-level visual verification plus focused tests:
- `RTL_LOCALES` / locale→direction resolution (root, frontend, component-library)
- `useTextDirection()` (Arabic, Hebrew, Spanish, English, locale changes)
- `<html dir="rtl">` for Arabic and Hebrew, `dir="ltr"` for an LTR locale, in `layout-dir.test.tsx`
- `RtlContainer` and `RtlAwareIcon` (mirroring, direction-neutral icons, context inheritance, LTR regression)
- Direction-sensitive accessibility behaviour and RTL/LTR layout behaviour
- Tailwind `rtl:` variant compile test and `globals.css` RTL utility checks

## Documentation

`I18N_README.md` gained an "RTL Language Support (Layout & Direction)" section covering supported RTL locales, how `RTL_LOCALES` works, `useTextDirection()`, building RTL-aware components, when to mirror icons, adding a new RTL locale, accessibility considerations and how to test RTL layouts.

## Validation

- Root: `npm test` (68), `npm run lint`, `npm run format:check` — all pass
- Frontend: `npm test` (86), `npm run lint`, `npx tsc --noEmit`, `npm run build` — all pass
- Component-library: `npm test` (21), `npm run lint`, `npx tsc --noEmit`, `npm run build` — all pass

Closes #436