### PR TITLE
fix: enforce minimum multi-sig requirements in propose_high_bounty_verification (#475)

### DIFF
--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -499,6 +499,14 @@ impl SecurityScannerContract {
         proposer.require_auth();
         Self::require_permission(&env, &proposer, Permission::VerifyVulnerability)?;
         
+        // Enforce minimum multi-sig requirements to prevent bypass
+        if required_approvals < 2 {
+            return Err(ContractError::InvalidInput);
+        }
+        if execution_delay < 3600 {
+            return Err(ContractError::InvalidInput);
+        }
+
         let parameters = vec![
             report_id.to_string(),
             bounty_amount.to_string(),


### PR DESCRIPTION
This PR addresses the critical multi-sig bypass vulnerability in `propose_high_bounty_verification()`.

### Fixes Included:
- **#475 (Multi-sig Bypass):** Enforced minimum requirements for `required_approvals` (>= 2) and `execution_delay` (>= 3600 seconds / 1 hour) when creating a multi-signature proposal for high-value bounty payouts.
- This prevents a single compromised or rogue Verifier from bypassing the multi-sig control by passing `required_approvals=1` and `execution_delay=0`, which would allow them to unilaterally approve and execute arbitrary high-value payouts.

These changes align the security controls for high bounties with those already in place for emergency verifications and role grants.