### PR TITLE
fix: require admin authentication in initialize() to prevent front-running (#474)

### DIFF
--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -373,6 +373,9 @@ impl SecurityScannerContract {
     
     /// Initialize the contract with admin address
     pub fn initialize(env: Env, admin: Address) -> Result<(), ContractError> {
+        // Require the admin address to authenticate itself to prevent front-running (#474)
+        admin.require_auth();
+        
         if env.storage().instance().has(&ADMIN) {
             return Err(ContractError::Unauthorized);
         }


### PR DESCRIPTION
This PR addresses the critical access control vulnerability in the contract's initializer.

### Fixes Included:
- **#474 (Uninitialized Contract Takeover):** Added `admin.require_auth()` to the `initialize()` function.
- This ensures that only the intended deployer (who must sign the transaction with the admin address) can initialize the contract and claim the `SuperAdmin` role.
- Prevents front-running attacks where an attacker could call `initialize()` before the legitimate deployer and permanently take over the protocol's administrative controls, treasury, and escrow systems.