### PR TITLE
Fix rememberMe checkbox doing nothing (#500)

### DIFF
--- a/frontend/__tests__/session.test.ts
+++ b/frontend/__tests__/session.test.ts
@@ -1,0 +1,69 @@
+import { persistSession, loadSession, clearSession } from '../lib/auth/session';
+
+describe('session persistence (rememberMe semantics)', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+
+  it('stores the session in localStorage when rememberMe is true', () => {
+    persistSession({ email: 'demo@example.com' }, true);
+
+    expect(window.localStorage.getItem('soroban_auth_session')).not.toBeNull();
+    expect(window.sessionStorage.getItem('soroban_auth_session')).toBeNull();
+  });
+
+  it('stores the session in sessionStorage when rememberMe is false', () => {
+    persistSession({ email: 'demo@example.com' }, false);
+
+    expect(window.sessionStorage.getItem('soroban_auth_session')).not.toBeNull();
+    expect(window.localStorage.getItem('soroban_auth_session')).toBeNull();
+  });
+
+  it('round-trips the stored user and rememberMe flag through loadSession', () => {
+    persistSession({ email: 'demo@example.com' }, true);
+
+    const session = loadSession<{ email: string }>();
+
+    expect(session).not.toBeNull();
+    expect(session?.user).toEqual({ email: 'demo@example.com' });
+    expect(session?.rememberMe).toBe(true);
+    expect(typeof session?.storedAt).toBe('number');
+  });
+
+  it('clears any prior session from the other storage when rememberMe changes', () => {
+    persistSession({ email: 'demo@example.com' }, true);
+    expect(window.localStorage.getItem('soroban_auth_session')).not.toBeNull();
+
+    persistSession({ email: 'demo@example.com' }, false);
+
+    expect(window.localStorage.getItem('soroban_auth_session')).toBeNull();
+    expect(window.sessionStorage.getItem('soroban_auth_session')).not.toBeNull();
+  });
+
+  it('returns null when no session has been persisted', () => {
+    expect(loadSession()).toBeNull();
+  });
+
+  it('clearSession removes the session from both storages', () => {
+    persistSession({ email: 'demo@example.com' }, true);
+    persistSession({ email: 'demo@example.com' }, false);
+
+    // Manually seed both storages to verify clearSession wipes both.
+    window.localStorage.setItem('soroban_auth_session', JSON.stringify({ user: {} }));
+
+    clearSession();
+
+    expect(window.localStorage.getItem('soroban_auth_session')).toBeNull();
+    expect(window.sessionStorage.getItem('soroban_auth_session')).toBeNull();
+    expect(loadSession()).toBeNull();
+  });
+
+  it('discards and cleans up a corrupted session entry instead of throwing', () => {
+    window.localStorage.setItem('soroban_auth_session', '{not valid json');
+
+    expect(() => loadSession()).not.toThrow();
+    expect(loadSession()).toBeNull();
+    expect(window.localStorage.getItem('soroban_auth_session')).toBeNull();
+  });
+});

--- a/frontend/app/auth/simple-page.tsx
+++ b/frontend/app/auth/simple-page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from 'react';
 import SimpleAuth, { LoginData, SignUpData } from '../../components/auth/SimpleAuth';
+import { persistSession } from '../../lib/auth/session';
 
 export default function SimpleAuthPage() {
   const [isLoading, setIsLoading] = useState(false);
@@ -16,6 +17,7 @@ export default function SimpleAuthPage() {
 
     // Mock validation
     if (data.email === 'demo@example.com' && data.password === 'password123') {
+      persistSession({ email: data.email }, data.rememberMe);
       console.log('Login successful');
       // In a real app, redirect to dashboard
     } else {

--- a/frontend/components/auth/AuthContainer.test.tsx
+++ b/frontend/components/auth/AuthContainer.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AuthContainer from './AuthContainer';
+
+const SESSION_KEY = 'soroban_auth_session';
+
+async function loginAndCompleteMfa(rememberMe: boolean) {
+  const user = userEvent.setup();
+  render(<AuthContainer />);
+
+  await user.type(screen.getByLabelText(/email address/i), 'demo@example.com');
+  await user.type(screen.getByLabelText(/^password$/i), 'password123');
+
+  if (rememberMe) {
+    await user.click(screen.getByLabelText(/remember me/i));
+  }
+
+  await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+  // The mock login always requires MFA before a session is established.
+  const codeInput = await screen.findByLabelText(/verification code/i, {}, { timeout: 3000 });
+  await user.type(codeInput, '123456');
+  await user.click(screen.getByRole('button', { name: /verify code/i }));
+
+  await waitFor(() => expect(screen.getByText(/authentication successful/i)).toBeInTheDocument(), {
+    timeout: 3000,
+  });
+}
+
+describe('AuthContainer - rememberMe session persistence', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+
+  it('does not persist a session until authentication (including MFA) fully completes', async () => {
+    const user = userEvent.setup();
+    render(<AuthContainer />);
+
+    await user.type(screen.getByLabelText(/email address/i), 'demo@example.com');
+    await user.type(screen.getByLabelText(/^password$/i), 'password123');
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await screen.findByLabelText(/verification code/i, {}, { timeout: 3000 });
+
+    expect(window.localStorage.getItem(SESSION_KEY)).toBeNull();
+    expect(window.sessionStorage.getItem(SESSION_KEY)).toBeNull();
+  });
+
+  it('persists the session in localStorage when rememberMe is checked', async () => {
+    await loginAndCompleteMfa(true);
+
+    expect(window.localStorage.getItem(SESSION_KEY)).not.toBeNull();
+    expect(window.sessionStorage.getItem(SESSION_KEY)).toBeNull();
+  }, 10000);
+
+  it('persists the session in sessionStorage (not localStorage) when rememberMe is unchecked', async () => {
+    await loginAndCompleteMfa(false);
+
+    expect(window.sessionStorage.getItem(SESSION_KEY)).not.toBeNull();
+    expect(window.localStorage.getItem(SESSION_KEY)).toBeNull();
+  }, 10000);
+});

--- a/frontend/components/auth/AuthContainer.tsx
+++ b/frontend/components/auth/AuthContainer.tsx
@@ -6,6 +6,7 @@ import SignUpForm from './SignUpForm';
 import PasswordResetForm from './PasswordResetForm';
 import MultiFactorAuth from './MultiFactorAuth';
 import { AlertCircle, CheckCircle } from 'lucide-react';
+import { persistSession } from '../../lib/auth/session';
 
 type AuthView = 'login' | 'signup' | 'reset-password' | 'mfa';
 
@@ -24,6 +25,7 @@ export default function AuthContainer({
   const [success, setSuccess] = useState<string | null>(null);
   const [userEmail, setUserEmail] = useState('');
   const [userPhone, setUserPhone] = useState('');
+  const [rememberMe, setRememberMe] = useState(false);
 
   const clearMessages = () => {
     setError(null);
@@ -111,6 +113,7 @@ export default function AuthContainer({
   }) => {
     clearMessages();
     setIsLoading(true);
+    setRememberMe(credentials.rememberMe);
 
     try {
       const result = await mockLogin(credentials);
@@ -119,6 +122,7 @@ export default function AuthContainer({
         setCurrentView('mfa');
         handleSuccess('Login successful! Please complete two-factor authentication.');
       } else {
+        persistSession(result.user, credentials.rememberMe);
         handleSuccess('Login successful!');
         onAuthSuccess?.(result.user);
       }
@@ -172,8 +176,10 @@ export default function AuthContainer({
 
     try {
       const result = await mockVerifyMfa(code, method);
+      const user = { email: userEmail, verified: true };
+      persistSession(user, rememberMe);
       handleSuccess('Authentication successful!');
-      onAuthSuccess?.({ email: userEmail, verified: true });
+      onAuthSuccess?.(user);
     } catch (err) {
       handleError(err instanceof Error ? err.message : 'Verification failed');
     } finally {

--- a/frontend/lib/auth/session.ts
+++ b/frontend/lib/auth/session.ts
@@ -1,0 +1,87 @@
+/**
+ * Client-side session persistence for the auth flows in `components/auth`.
+ *
+ * Previously, the "Remember me" checkbox on the login form was collected
+ * but never used anywhere — it had no effect on session behavior, which
+ * misled users into thinking it changed how long they'd stay signed in
+ * (see issue #500).
+ *
+ * This module gives the flag real, verifiable behavior:
+ *   - rememberMe = true  -> the session is written to localStorage, so it
+ *     survives closing the tab/browser and is restored on the next visit.
+ *   - rememberMe = false -> the session is written to sessionStorage, so
+ *     it is cleared as soon as the tab/window is closed.
+ *
+ * This intentionally only controls *where* the client keeps its local copy
+ * of the session (persistent vs. tab-scoped storage). It does not change
+ * how a session is authenticated or refreshed against a backend — that
+ * remains the responsibility of the API layer once one exists.
+ */
+
+const SESSION_STORAGE_KEY = 'soroban_auth_session';
+
+export interface StoredSession<T = unknown> {
+  user: T;
+  rememberMe: boolean;
+  /** Epoch ms when the session was persisted. */
+  storedAt: number;
+}
+
+function getTargetStorage(rememberMe: boolean): Storage | null {
+  if (typeof window === 'undefined') return null;
+  return rememberMe ? window.localStorage : window.sessionStorage;
+}
+
+/**
+ * Persist a session for the given user, honoring the rememberMe flag.
+ *
+ * Any previously stored session (in either storage) is cleared first, so
+ * toggling the flag between logins never leaves a stale duplicate behind
+ * in the other storage.
+ */
+export function persistSession<T>(user: T, rememberMe: boolean): void {
+  if (typeof window === 'undefined') return;
+
+  clearSession();
+
+  const session: StoredSession<T> = {
+    user,
+    rememberMe,
+    storedAt: Date.now(),
+  };
+
+  const storage = getTargetStorage(rememberMe);
+  storage?.setItem(SESSION_STORAGE_KEY, JSON.stringify(session));
+}
+
+/**
+ * Load a previously persisted session, if any.
+ *
+ * Checks localStorage first (a "remembered" session that outlives the
+ * tab), then falls back to sessionStorage (a session scoped to the
+ * current tab/window).
+ */
+export function loadSession<T = unknown>(): StoredSession<T> | null {
+  if (typeof window === 'undefined') return null;
+
+  for (const storage of [window.localStorage, window.sessionStorage]) {
+    const raw = storage.getItem(SESSION_STORAGE_KEY);
+    if (!raw) continue;
+
+    try {
+      return JSON.parse(raw) as StoredSession<T>;
+    } catch {
+      // Corrupt entry — remove it and keep looking in the other storage.
+      storage.removeItem(SESSION_STORAGE_KEY);
+    }
+  }
+
+  return null;
+}
+
+/** Remove any persisted session from both localStorage and sessionStorage. */
+export function clearSession(): void {
+  if (typeof window === 'undefined') return;
+  window.localStorage.removeItem(SESSION_STORAGE_KEY);
+  window.sessionStorage.removeItem(SESSION_STORAGE_KEY);
+}


### PR DESCRIPTION
Closes #500

The rememberMe checkbox on the login form looked like it did something but 
it didn't - the value was collected in LoginForm/SimpleAuth and then just... 
dropped. Nobody ever read it.

I added a small session helper (frontend/lib/auth/session.ts) that actually 
uses the flag:
- checked -> session goes in localStorage, so it survives closing the browser
- unchecked -> session goes in sessionStorage, so it's gone once you close the tab

Wired it into AuthContainer and the simple-page login flow. Session only gets 
saved once login is fully done (after MFA too, not before).

Worth noting there's no real backend auth here yet, both login flows are 
still mocked, so this is really about fixing what the frontend itself 
controls - where the session lives locally. Once real auth exists this 
same pattern should still hold up.

Added tests for the storage helper and for the full login -> MFA -> session 
flow to make sure the right storage gets used each time.

Ran the full suite + typecheck + lint + build locally, all passing.