### PR TITLE
fix(escrow): verify release signature before releasing funds (#481)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ target/
 *.rcgu.o
 *.d
 
+# Soroban test execution snapshots
+test_snapshots/
+
 # Environment files
 .env
 .env.local

--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -30,6 +30,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "ark-bls12-381"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,6 +340,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67773048316103656a637612c4a62477603b777d91d9c62ff2290f9cde178fdb"
+dependencies = [
+ "ctor-proc-macro",
+ "dtor",
+]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,6 +477,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,6 +504,21 @@ name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "dtor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "404d02eeb088a82cfd873006cb713fe411306c7d182c344905e101fb1167d301"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "dyn-clone"
@@ -1149,6 +1200,7 @@ dependencies = [
 name = "security_scanner"
 version = "1.0.0"
 dependencies = [
+ "ed25519-dalek",
  "soroban-sdk",
 ]
 
@@ -1301,10 +1353,12 @@ version = "26.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c76fad735f9622d8aa0fa0c75838d2023a659a0c57638a783b8b2eb967f7822"
 dependencies = [
+ "arbitrary",
  "crate-git-revision",
  "ethnum",
  "num-derive",
  "num-traits",
+ "serde",
  "soroban-env-macros",
  "soroban-wasmi",
  "static_assertions",
@@ -1375,19 +1429,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "soroban-ledger-snapshot"
+version = "26.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9ee1c6ba495aa33b281a5818ece9b91f94ddbee93f08637d081983c36290ca"
+dependencies = [
+ "serde",
+ "serde_json",
+ "serde_with",
+ "soroban-env-common",
+ "soroban-env-host",
+ "thiserror",
+]
+
+[[package]]
 name = "soroban-sdk"
 version = "26.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8c92772aaafb45bbfa8ea5baa5b453e84be4351ddb6383469acbcf3d64ddc8e"
 dependencies = [
+ "arbitrary",
  "bytes-lit",
  "crate-git-revision",
+ "ctor",
+ "derive_arbitrary",
+ "ed25519-dalek",
  "rand",
  "rustc_version",
  "serde",
  "serde_json",
  "soroban-env-guest",
  "soroban-env-host",
+ "soroban-ledger-snapshot",
  "soroban-sdk-macros",
  "stellar-strkey 0.0.16",
  "visibility",
@@ -1510,6 +1583,7 @@ version = "26.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6e29c7e1f071c2767916460d006668197843d5d93f0ec8893a26f72a14f595"
 dependencies = [
+ "arbitrary",
  "base64",
  "cfg_eval",
  "crate-git-revision",

--- a/contracts/scanner/Cargo.toml
+++ b/contracts/scanner/Cargo.toml
@@ -11,4 +11,10 @@ doctest = false
 [dependencies]
 soroban-sdk = { workspace = true, features = ["alloc"] }
 
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["alloc", "testutils"] }
+# Deterministic ed25519 signing for the release-signature tests. Already in the
+# dependency tree via soroban-env-host, so this pulls in no new crate version.
+ed25519-dalek = "2"
+
 

--- a/contracts/scanner/src/lib.rs
+++ b/contracts/scanner/src/lib.rs
@@ -3,8 +3,8 @@ extern crate alloc;
 use alloc::format;
 use alloc::string::ToString;
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, vec, Address, Bytes, BytesN,
-    Env, Map, String, Symbol, Vec,
+    contract, contracterror, contractimpl, contracttype, symbol_short, vec, xdr::ToXdr, Address,
+    Bytes, BytesN, Env, Map, String, Symbol, Vec,
 };
 
 // Contract state keys
@@ -141,7 +141,13 @@ pub struct EscrowEntry {
     pub created_at: u64,
     pub lock_until: u64,
     pub conditions_met: bool,
-    pub release_signature: Option<Bytes>,
+    /// Optional ed25519 public key that must authorize a release. When set,
+    /// `release_escrow` requires a valid signature over the escrow's canonical
+    /// release message; when `None`, release falls back to depositor auth only.
+    pub release_signer: Option<BytesN<32>>,
+    /// The verified ed25519 signature that authorized the release. Only ever
+    /// populated with a signature that passed `ed25519_verify` (Issue #481).
+    pub release_signature: Option<BytesN<64>>,
 }
 
 // Emergency alert structure
@@ -231,6 +237,28 @@ impl SecurityScannerContract {
         );
         let bytes = Bytes::from_slice(env, payload.as_bytes());
         env.crypto().sha256(&bytes).into()
+    }
+
+    /// Load the per-escrow nonce created in `create_escrow`.
+    fn escrow_nonce(env: &Env, escrow_id: u64) -> Result<BytesN<32>, ContractError> {
+        let escrow_nonces: Map<u64, BytesN<32>> = env
+            .storage()
+            .instance()
+            .get(&ESCROW_NONCES)
+            .unwrap_or(Map::new(env));
+        escrow_nonces.get(escrow_id).ok_or(ContractError::NotFound)
+    }
+
+    /// Build the canonical message a release signer must sign to authorize a
+    /// release. Binding the escrow's unique nonce, id, beneficiary and amount
+    /// ties the signature to exactly one payout and prevents it from being
+    /// replayed against a different escrow or a mutated amount.
+    fn build_release_message(env: &Env, escrow: &EscrowEntry, nonce: &BytesN<32>) -> Bytes {
+        let mut message = Bytes::from_array(env, &nonce.to_array());
+        message.extend_from_array(&escrow.id.to_be_bytes());
+        message.append(&escrow.beneficiary.clone().to_xdr(env));
+        message.extend_from_array(&escrow.amount.to_be_bytes());
+        message
     }
 
     // Role-based access control helper functions
@@ -754,6 +782,7 @@ impl SecurityScannerContract {
         amount: i128,
         purpose: String,
         lock_duration: u64,
+        release_signer: Option<BytesN<32>>,
     ) -> Result<u64, ContractError> {
         depositor.require_auth();
         Self::require_non_default_address(&depositor)?;
@@ -776,6 +805,7 @@ impl SecurityScannerContract {
             created_at: current_time,
             lock_until,
             conditions_met: false,
+            release_signer,
             release_signature: None,
         };
 
@@ -807,7 +837,7 @@ impl SecurityScannerContract {
         env: Env,
         escrow_id: u64,
         depositor: Address,
-        signature: Option<Bytes>,
+        signature: Option<BytesN<64>>,
     ) -> Result<(), ContractError> {
         depositor.require_auth();
 
@@ -835,11 +865,28 @@ impl SecurityScannerContract {
             return Err(ContractError::EscrowLocked);
         }
 
+        // Enforce the signature-based release control. If the escrow was created
+        // with a `release_signer`, the caller must present an ed25519 signature
+        // over the escrow's canonical release message; anything else is rejected.
+        // Previously the `signature` argument was stored without ever being
+        // checked, so the control was purely decorative (Issue #481).
+        let verified_signature = match &escrow.release_signer {
+            Some(signer) => {
+                let signature = signature.ok_or(ContractError::Unauthorized)?;
+                let nonce = Self::escrow_nonce(&env, escrow_id)?;
+                let message = Self::build_release_message(&env, &escrow, &nonce);
+                // Panics (aborting the transaction) if the signature is invalid.
+                env.crypto().ed25519_verify(signer, &message, &signature);
+                Some(signature)
+            }
+            None => None,
+        };
+
         Self::execute_payout_placeholder(&env, &escrow.beneficiary, escrow.amount, escrow_id)?;
 
         // Update escrow status
         escrow.status = String::from_str(&env, "released");
-        escrow.release_signature = signature;
+        escrow.release_signature = verified_signature;
         escrows.set(escrow_id, escrow.clone());
         env.storage().instance().set(&ESCROWS, &escrows);
 
@@ -1138,7 +1185,8 @@ impl SecurityScannerContract {
                 alert.reporter.clone(),
                 alert.emergency_reward,
                 String::from_str(&env, "emergency"),
-                0, // No lock period for emergency rewards
+                0,    // No lock period for emergency rewards
+                None, // Emergency releases are authorized by admin auth, not a signer
             )?;
 
             // Immediately mark conditions as met and release
@@ -1170,6 +1218,15 @@ impl SecurityScannerContract {
             .get(&ESCROWS)
             .unwrap_or(Map::new(&env));
         escrows.get(escrow_id).ok_or(ContractError::NotFound)
+    }
+
+    /// Canonical message that an escrow's registered `release_signer` must sign
+    /// (raw, unhashed) to authorize a release via `release_escrow`. Returns
+    /// `NotFound` if the escrow does not exist.
+    pub fn escrow_release_message(env: Env, escrow_id: u64) -> Result<Bytes, ContractError> {
+        let escrow = Self::get_escrow(env.clone(), escrow_id)?;
+        let nonce = Self::escrow_nonce(&env, escrow_id)?;
+        Ok(Self::build_release_message(&env, &escrow, &nonce))
     }
 
     /// Get emergency alert details

--- a/contracts/scanner/tests/escrow_release_signature.rs
+++ b/contracts/scanner/tests/escrow_release_signature.rs
@@ -1,0 +1,168 @@
+//! Regression tests for Issue #481: `release_escrow` must actually verify the
+//! release signature instead of storing it unchecked.
+//!
+//! These run against the real contract through the generated client, and the
+//! signatures are produced with `ed25519-dalek` so we exercise the same
+//! ed25519 scheme the Soroban host verifies with.
+
+use ed25519_dalek::{Signer, SigningKey};
+use security_scanner::{ContractError, SecurityScannerContract, SecurityScannerContractClient};
+use soroban_sdk::{testutils::Address as _, Address, Bytes, BytesN, Env, String};
+
+/// Deterministic keypair from a seed byte, returning the dalek signing key and
+/// its public key as the `BytesN<32>` the contract expects as a release signer.
+fn make_signer(env: &Env, seed: u8) -> (SigningKey, BytesN<32>) {
+    let signing_key = SigningKey::from_bytes(&[seed; 32]);
+    let public_key = BytesN::from_array(env, &signing_key.verifying_key().to_bytes());
+    (signing_key, public_key)
+}
+
+/// Sign a canonical release message and hand back a `BytesN<64>` signature.
+fn sign_message(env: &Env, signing_key: &SigningKey, message: &Bytes) -> BytesN<64> {
+    let bytes = message.to_alloc_vec();
+    let signature = signing_key.sign(bytes.as_slice());
+    BytesN::from_array(env, &signature.to_bytes())
+}
+
+fn setup() -> (Env, SecurityScannerContractClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(SecurityScannerContract, ());
+    let client = SecurityScannerContractClient::new(&env, &contract_id);
+    (env, client)
+}
+
+#[test]
+fn release_with_valid_signature_succeeds() {
+    let (env, client) = setup();
+    let depositor = Address::generate(&env);
+    let beneficiary = Address::generate(&env);
+    let (signing_key, public_key) = make_signer(&env, 7);
+
+    let escrow_id = client.create_escrow(
+        &depositor,
+        &beneficiary,
+        &1_000i128,
+        &String::from_str(&env, "bounty"),
+        &0u64,
+        &Some(public_key),
+    );
+
+    let message = client.escrow_release_message(&escrow_id);
+    let signature = sign_message(&env, &signing_key, &message);
+
+    client.release_escrow(&escrow_id, &depositor, &Some(signature.clone()));
+
+    let escrow = client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, String::from_str(&env, "released"));
+    // Only a signature that actually verified should ever be persisted.
+    assert_eq!(escrow.release_signature, Some(signature));
+}
+
+#[test]
+fn release_without_signature_is_rejected_when_signer_required() {
+    let (env, client) = setup();
+    let depositor = Address::generate(&env);
+    let beneficiary = Address::generate(&env);
+    let (_signing_key, public_key) = make_signer(&env, 9);
+
+    let escrow_id = client.create_escrow(
+        &depositor,
+        &beneficiary,
+        &1_000i128,
+        &String::from_str(&env, "bounty"),
+        &0u64,
+        &Some(public_key),
+    );
+
+    // A registered signer but no signature: the release must be refused.
+    let result = client.try_release_escrow(&escrow_id, &depositor, &None);
+    assert_eq!(result, Err(Ok(ContractError::Unauthorized)));
+
+    // ...and the funds stay put.
+    let escrow = client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, String::from_str(&env, "pending"));
+}
+
+#[test]
+fn release_with_forged_signature_is_rejected() {
+    let (env, client) = setup();
+    let depositor = Address::generate(&env);
+    let beneficiary = Address::generate(&env);
+    let (_registered_key, registered_pk) = make_signer(&env, 11);
+    let (attacker_key, _attacker_pk) = make_signer(&env, 12);
+
+    let escrow_id = client.create_escrow(
+        &depositor,
+        &beneficiary,
+        &1_000i128,
+        &String::from_str(&env, "bounty"),
+        &0u64,
+        &Some(registered_pk),
+    );
+
+    // Correct message, but signed by the wrong key. ed25519_verify rejects it,
+    // aborting the release.
+    let message = client.escrow_release_message(&escrow_id);
+    let forged = sign_message(&env, &attacker_key, &message);
+
+    let result = client.try_release_escrow(&escrow_id, &depositor, &Some(forged));
+    assert!(
+        result.is_err(),
+        "forged signature must not release the escrow"
+    );
+
+    let escrow = client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, String::from_str(&env, "pending"));
+}
+
+#[test]
+fn release_without_signer_keeps_legacy_behavior() {
+    let (env, client) = setup();
+    let depositor = Address::generate(&env);
+    let beneficiary = Address::generate(&env);
+
+    // No release signer registered — this is the path the emergency-reward flow
+    // relies on, authorized purely by depositor auth.
+    let escrow_id = client.create_escrow(
+        &depositor,
+        &beneficiary,
+        &1_000i128,
+        &String::from_str(&env, "bounty"),
+        &0u64,
+        &None,
+    );
+
+    client.release_escrow(&escrow_id, &depositor, &None);
+
+    let escrow = client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, String::from_str(&env, "released"));
+    assert_eq!(escrow.release_signature, None);
+}
+
+#[test]
+fn signature_is_ignored_when_no_signer_registered() {
+    let (env, client) = setup();
+    let depositor = Address::generate(&env);
+    let beneficiary = Address::generate(&env);
+
+    let escrow_id = client.create_escrow(
+        &depositor,
+        &beneficiary,
+        &1_000i128,
+        &String::from_str(&env, "bounty"),
+        &0u64,
+        &None,
+    );
+
+    // A well-formed signature over unrelated bytes. With no signer registered it
+    // is neither required nor trusted, so it must not be stored on the escrow.
+    let (stray_key, _pk) = make_signer(&env, 3);
+    let stray = sign_message(&env, &stray_key, &Bytes::from_array(&env, &[0u8; 8]));
+
+    client.release_escrow(&escrow_id, &depositor, &Some(stray));
+
+    let escrow = client.get_escrow(&escrow_id);
+    assert_eq!(escrow.status, String::from_str(&env, "released"));
+    assert_eq!(escrow.release_signature, None);
+}


### PR DESCRIPTION
## Summary

`release_escrow()` accepted a `signature` argument and stored it on the escrow, but never verified it. The "release requires a valid signature" control didn't actually exist — the only gate was `depositor.require_auth()`, and any caller who passed that could release funds with a garbage or forged signature.

This PR makes the signature check real instead of removing it, so the intended control works.

## Root cause

In `release_escrow()` the signature was written straight to state:

```rust
escrow.release_signature = signature; // never checked
```

There was no `ed25519_verify` (or any comparison) against an expected signer or message. The per-escrow nonce generated in `create_escrow()` was also never used anywhere, so the signing feature was only half-built.

## Changes

- `create_escrow()` takes an optional `release_signer` (an ed25519 public key, `BytesN<32>`).
  - When a signer is registered, `release_escrow()` now **requires** a signature and verifies it with `env.crypto().ed25519_verify()` before paying out. A missing signature returns `Unauthorized`; an invalid one aborts the transaction.
  - When no signer is registered, behaviour is unchanged (depositor auth only). The internal emergency-reward flow passes `None`, so it keeps working exactly as before.
- The signed message binds the escrow's **nonce, id, beneficiary and amount**, so a signature can't be replayed against a different escrow or a tampered amount. This is what finally consumes the previously-unused per-escrow nonce.
- `release_signature` is now typed `Option<BytesN<64>>` and only ever holds a signature that actually verified — unverified input is never persisted.
- Added `escrow_release_message()` so integrators (and the tests) can fetch the exact bytes to sign.

## Tests

New integration tests in `contracts/scanner/tests/escrow_release_signature.rs`, signing with `ed25519-dalek` so we exercise the real ed25519 scheme:

- valid signature → releases, and the verified signature is stored
- signer registered but signature missing → `Unauthorized`, escrow stays `pending`
- forged signature (wrong key) → release is rejected, escrow stays `pending`
- no signer registered → legacy depositor-auth release still works, nothing stored

Local checks (contracts workspace):

- `cargo fmt --check`
- `cargo clippy --lib -- -D warnings`
- `cargo test -p security_scanner` — 5 passed
- `cargo build --target wasm32v1-none --release`

## Note

`create_escrow` and `release_escrow` change signature (a new `release_signer` parameter, and the release signature is now `BytesN<64>` rather than `Bytes`). The only in-tree callers are the internal emergency path, which have been updated.

Closes #481
