### PR TITLE
fix(scanner): require admin auth in initialize() to prevent takeover (#474)

### DIFF
--- a/contracts/scanner/src/lib.rs
+++ b/contracts/scanner/src/lib.rs
@@ -469,6 +469,14 @@ impl SecurityScannerContract {
 
     /// Initialize the contract with admin address
     pub fn initialize(env: Env, admin: Address) -> Result<(), ContractError> {
+        // Require the designated admin to authorize initialization. Without this,
+        // `initialize` is permissionless: any account can front-run the legitimate
+        // deployer and register an address it controls as ADMIN / SuperAdmin, since
+        // the only other guard is the "already initialized" check below. Requiring
+        // the admin's own signature ensures the SuperAdmin slot cannot be seized on
+        // behalf of an address the caller does not control.
+        admin.require_auth();
+
         if env.storage().instance().has(&ADMIN) {
             return Err(ContractError::Unauthorized);
         }


### PR DESCRIPTION
## Summary
`initialize()` had no access control. The only guard was the "already initialized" check, so **any account could front-run the legitimate deployer** and register an address it controls as `ADMIN` and `SuperAdmin` — a classic uninitialized-contract takeover.

With SuperAdmin, an attacker could propose/approve role grants, verify vulnerabilities, and move bounty/escrow funds.

## Fix
Add `admin.require_auth()` at the top of `initialize()`. Initialization must now be authorized by the address being installed as SuperAdmin, so the admin/SuperAdmin slot can no longer be claimed on behalf of an address the caller does not control.

## Verification (local, mirrors the CI `contracts` job)
- `cargo fmt --check` ✅
- `cargo clippy --lib -- -D warnings` ✅
- `cargo test -p security_scanner` ✅ (5 passed)
- `cargo build --target wasm32v1-none --release` ✅

Closes #474

🤖 Generated with [Claude Code](https://claude.com/claude-code)
