### PR TITLE
Fix #483: harden multi-sig parameter parsing and role-grant address handling

### DIFF
--- a/contracts/scanner/src/lib.rs
+++ b/contracts/scanner/src/lib.rs
@@ -172,10 +172,40 @@ pub struct SecurityScannerContract;
 
 #[contractimpl]
 impl SecurityScannerContract {
-    fn sdk_string_to_rust(s: soroban_sdk::String) -> alloc::string::String {
+    /// Convert an SDK string to a Rust `String`, returning [`ContractError::InvalidInput`]
+    /// on invalid UTF-8 instead of panicking. A panic here traps the whole
+    /// transaction, so untrusted proposal parameters must never be able to trigger one.
+    fn sdk_string_to_rust(s: soroban_sdk::String) -> Result<alloc::string::String, ContractError> {
         let bytes = s.to_bytes();
         let vec = bytes.to_alloc_vec();
-        alloc::string::String::from_utf8(vec).expect("invalid utf-8")
+        alloc::string::String::from_utf8(vec).map_err(|_| ContractError::InvalidInput)
+    }
+
+    /// Fetch parameter `idx` from a proposal parameter list, erroring instead of
+    /// panicking when the index is out of range.
+    fn proposal_param(parameters: &Vec<String>, idx: u32) -> Result<String, ContractError> {
+        parameters.get(idx).ok_or(ContractError::InvalidInput)
+    }
+
+    /// Parse proposal parameter `idx` as `u64` without panicking.
+    fn parse_param_u64(parameters: &Vec<String>, idx: u32) -> Result<u64, ContractError> {
+        Self::sdk_string_to_rust(Self::proposal_param(parameters, idx)?)?
+            .parse()
+            .map_err(|_| ContractError::InvalidInput)
+    }
+
+    /// Parse proposal parameter `idx` as `i128` without panicking.
+    fn parse_param_i128(parameters: &Vec<String>, idx: u32) -> Result<i128, ContractError> {
+        Self::sdk_string_to_rust(Self::proposal_param(parameters, idx)?)?
+            .parse()
+            .map_err(|_| ContractError::InvalidInput)
+    }
+
+    /// Parse proposal parameter `idx` as `bool` without panicking.
+    fn parse_param_bool(parameters: &Vec<String>, idx: u32) -> Result<bool, ContractError> {
+        Self::sdk_string_to_rust(Self::proposal_param(parameters, idx)?)?
+            .parse()
+            .map_err(|_| ContractError::InvalidInput)
     }
 
     fn require_non_default_address(addr: &Address) -> Result<(), ContractError> {
@@ -671,12 +701,8 @@ impl SecurityScannerContract {
             .get(proposal_id)
             .ok_or(ContractError::ProposalNotFound)?;
 
-        let report_id: u64 = Self::sdk_string_to_rust(proposal.parameters.get(0).unwrap())
-            .parse()
-            .unwrap();
-        let bounty_amount: i128 = Self::sdk_string_to_rust(proposal.parameters.get(1).unwrap())
-            .parse()
-            .unwrap();
+        let report_id: u64 = Self::parse_param_u64(&proposal.parameters, 0)?;
+        let bounty_amount: i128 = Self::parse_param_i128(&proposal.parameters, 1)?;
 
         // Execute the verification
         Self::verify_vulnerability(env.clone(), executor, report_id, bounty_amount)?;
@@ -1132,12 +1158,8 @@ impl SecurityScannerContract {
             .get(proposal_id)
             .ok_or(ContractError::ProposalNotFound)?;
 
-        let alert_id: u64 = Self::sdk_string_to_rust(proposal.parameters.get(0).unwrap())
-            .parse()
-            .unwrap();
-        let verified: bool = Self::sdk_string_to_rust(proposal.parameters.get(1).unwrap())
-            .parse()
-            .unwrap();
+        let alert_id: u64 = Self::parse_param_u64(&proposal.parameters, 0)?;
+        let verified: bool = Self::parse_param_bool(&proposal.parameters, 1)?;
 
         // Execute the emergency verification
         Self::execute_emergency_verification_internal(env.clone(), executor, alert_id, verified)?;
@@ -1312,11 +1334,7 @@ impl SecurityScannerContract {
             Role::TreasuryManager => "TreasuryManager",
         };
 
-        let parameters = vec![
-            &env,
-            String::from_str(&env, &format!("{:?}", user)),
-            String::from_str(&env, role_str),
-        ];
+        let parameters = vec![&env, user.to_string(), String::from_str(&env, role_str)];
 
         // Role management has higher security requirements
         let role_delay = if execution_delay < 86400 {
@@ -1374,11 +1392,13 @@ impl SecurityScannerContract {
             .get(proposal_id)
             .ok_or(ContractError::ProposalNotFound)?;
 
-        let user_addr_s = Self::sdk_string_to_rust(proposal.parameters.get(0).unwrap());
-        let role_s = Self::sdk_string_to_rust(proposal.parameters.get(1).unwrap());
-
-        // Parse address and role (simplified for this example)
-        let user_address = Address::from_string(&String::from_str(&env, &user_addr_s));
+        // The user address is stored in canonical strkey form (see
+        // `propose_role_grant`), so reconstruct it directly from the stored SDK
+        // string. The previous code stored `format!("{:?}", user)` and rebuilt the
+        // address from that `Debug` output, which is not a valid strkey — so the
+        // granted address could differ from the one that was proposed and approved.
+        let user_address = Address::from_string(&Self::proposal_param(&proposal.parameters, 0)?);
+        let role_s = Self::sdk_string_to_rust(Self::proposal_param(&proposal.parameters, 1)?)?;
         let role = match role_s.as_str() {
             "SuperAdmin" => Role::SuperAdmin,
             "Verifier" => Role::Verifier,


### PR DESCRIPTION
## Summary
The multi-sig **execute** path parsed untrusted proposal parameters with panicking conversions, and the role-grant path serialized the target address with `format!("{:?}", ..)` (Debug) and later rebuilt it with `Address::from_string`. Two problems:

1. **Panics trap the transaction.** `sdk_string_to_rust` used `.expect("invalid utf-8")`, and every execute path used `.get(idx).unwrap()` + `.parse().unwrap()`. Malformed parameters (bad UTF-8, missing index, non-numeric) abort the whole call instead of returning a clean error.
2. **Non-canonical address round-trip.** `propose_role_grant` stored `format!("{:?}", user)`, whose `Debug` output is **not** a valid strkey. Reconstructing the address from that string in `execute_role_grant` is unreliable — the address actually granted the role can differ from the one that was proposed and approved.

## Fix
- `sdk_string_to_rust` now returns `Result<_, ContractError::InvalidInput>` instead of panicking on invalid UTF-8.
- Added non-panicking helpers `proposal_param` / `parse_param_u64` / `parse_param_i128` / `parse_param_bool`; all execute paths (`report_id`, `bounty_amount`, `alert_id`, `verified`) use them and propagate `InvalidInput` with `?`.
- `propose_role_grant` now stores `user.to_string()` (canonical strkey), and `execute_role_grant` rebuilds the address directly from the stored SDK string via `Address::from_string` — a lossless round-trip.

Serialization on the propose side is unchanged for the numeric/bool params (still decimal / `true`/`false`), so stored proposals parse back identically.

## Verification (local, mirrors the CI `contracts` job)
- `cargo fmt --check` ✅
- `cargo clippy --lib -- -D warnings` ✅
- `cargo test -p security_scanner` ✅
- `cargo build --target wasm32v1-none --release` ✅

Closes #483

🤖 Generated with [Claude Code](https://claude.com/claude-code)
