### PR TITLE
fix(frontend): tighten production CSP

### DIFF
--- a/frontend/__tests__/security-headers.test.ts
+++ b/frontend/__tests__/security-headers.test.ts
@@ -101,6 +101,29 @@ describe('Security Headers Middleware', () => {
       expect(cspHeader).toContain('https://horizon-futurenet.stellar.org');
     });
 
+    it('should allow local WebSocket connections only outside production', () => {
+      const developmentResponse = middleware(mockRequest);
+      const developmentCsp = developmentResponse.headers.get(
+        'Content-Security-Policy-Report-Only'
+      );
+
+      expect(developmentCsp).toContain('ws://localhost:*');
+
+      (process.env as any).NODE_ENV = 'production';
+      const productionResponse = middleware(mockRequest);
+      const productionCsp = productionResponse.headers.get('Content-Security-Policy');
+
+      expect(productionCsp).not.toContain('ws://localhost:*');
+    });
+
+    it('should not allow wildcard Stellar WebSockets or deprecated mixed-content directives', () => {
+      const response = middleware(mockRequest);
+      const cspHeader = response.headers.get('Content-Security-Policy-Report-Only');
+
+      expect(cspHeader).not.toContain('wss://*.stellar.org');
+      expect(cspHeader).not.toContain('block-all-mixed-content');
+    });
+
     it('should set frame-ancestors to none', () => {
       const response = middleware(mockRequest);
 

--- a/frontend/__tests__/security-headers.test.ts
+++ b/frontend/__tests__/security-headers.test.ts
@@ -103,9 +103,7 @@ describe('Security Headers Middleware', () => {
 
     it('should allow local WebSocket connections only outside production', () => {
       const developmentResponse = middleware(mockRequest);
-      const developmentCsp = developmentResponse.headers.get(
-        'Content-Security-Policy-Report-Only'
-      );
+      const developmentCsp = developmentResponse.headers.get('Content-Security-Policy-Report-Only');
 
       expect(developmentCsp).toContain('ws://localhost:*');
 

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -30,9 +30,20 @@ function generateNonce(): string {
  * Build Content Security Policy header value
  *
  * @param nonce - Cryptographic nonce for inline scripts
- * @param reportOnly - Whether to use report-only mode (for testing)
+ * @param isProduction - Whether to exclude development-only connection sources
  */
-function buildCSP(nonce: string, reportOnly: boolean = false): string {
+function buildCSP(nonce: string, isProduction: boolean): string {
+  const connectSources = [
+    "'self'",
+    'https://horizon.stellar.org', // Mainnet
+    'https://horizon-testnet.stellar.org', // Testnet
+    'https://horizon-futurenet.stellar.org', // Futurenet
+  ];
+
+  if (!isProduction) {
+    connectSources.push('ws://localhost:*');
+  }
+
   const directives: CSPDirectives = {
     // Default fallback for all resource types
     'default-src': ["'self'"],
@@ -58,15 +69,9 @@ function buildCSP(nonce: string, reportOnly: boolean = false): string {
     // Fonts: self-hosted only
     'font-src': ["'self'"],
 
-    // API connections: self + Stellar Horizon endpoints + WebSocket
-    'connect-src': [
-      "'self'",
-      'https://horizon.stellar.org', // Mainnet
-      'https://horizon-testnet.stellar.org', // Testnet
-      'https://horizon-futurenet.stellar.org', // Futurenet
-      'ws://localhost:*', // Local WebSocket development
-      'wss://*.stellar.org', // Stellar WebSocket endpoints
-    ],
+    // API connections: self + the exact Stellar Horizon endpoints used by the app.
+    // Local WebSocket access is development-only.
+    'connect-src': connectSources,
 
     // Frames: completely disabled
     'frame-src': ["'none'"],
@@ -86,8 +91,6 @@ function buildCSP(nonce: string, reportOnly: boolean = false): string {
     // Upgrade insecure requests (HTTP -> HTTPS)
     'upgrade-insecure-requests': [],
 
-    // Block mixed content
-    'block-all-mixed-content': [],
   };
 
   // Convert directives object to CSP string
@@ -110,7 +113,7 @@ function getSecurityHeaders(nonce: string, isProduction: boolean): Record<string
     // Use report-only in development, enforcing in production
     [isProduction ? 'Content-Security-Policy' : 'Content-Security-Policy-Report-Only']: buildCSP(
       nonce,
-      !isProduction
+      isProduction
     ),
 
     // HTTP Strict Transport Security (HSTS)

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -90,7 +90,6 @@ function buildCSP(nonce: string, isProduction: boolean): string {
 
     // Upgrade insecure requests (HTTP -> HTTPS)
     'upgrade-insecure-requests': [],
-
   };
 
   // Convert directives object to CSP string


### PR DESCRIPTION
## Summary
- restrict localhost WebSocket access to non-production CSPs
- remove the unused broad Stellar WebSocket wildcard
- remove the deprecated `block-all-mixed-content` directive
- add focused production and development CSP tests

## Validation
- `npm test -- --runInBand __tests__/security-headers.test.ts`
- 27 tests passed

Closes #497