### PR TITLE
Fix #432: client-side magic byte validation for file uploads

### DIFF
--- a/frontend/__tests__/useFileUpload.magic.test.ts
+++ b/frontend/__tests__/useFileUpload.magic.test.ts
@@ -1,0 +1,71 @@
+import { detectContentError, getExt, readHeadBytes, WASM_MAGIC } from '../hooks/useFileUpload';
+
+function makeFile(parts: BlobPart[], name: string, type = ''): File {
+  return new File(parts, name, { type });
+}
+
+describe('getExt', () => {
+  it('returns the lower-cased extension including the dot', () => {
+    expect(getExt('Contract.WASM')).toBe('.wasm');
+    expect(getExt('src/lib.rs')).toBe('.rs');
+  });
+});
+
+describe('readHeadBytes', () => {
+  it('reads only the requested number of leading bytes', async () => {
+    const file = makeFile([new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8])], 'blob.bin');
+    const head = await readHeadBytes(file, 4);
+    expect(Array.from(head)).toEqual([1, 2, 3, 4]);
+  });
+});
+
+describe('detectContentError – client-side magic byte validation', () => {
+  it('accepts a valid .wasm file (starts with \\0asm)', async () => {
+    const bytes = new Uint8Array([...WASM_MAGIC, 0x01, 0x00, 0x00, 0x00]);
+    const file = makeFile([bytes], 'contract.wasm', 'application/wasm');
+    expect(await detectContentError(file, '.wasm')).toBeNull();
+  });
+
+  it('rejects a .wasm that is really an .exe renamed (MZ header)', async () => {
+    // 0x4D 0x5A = "MZ", the DOS/PE executable signature.
+    const bytes = new Uint8Array([0x4d, 0x5a, 0x90, 0x00, 0x03, 0x00]);
+    const file = makeFile([bytes], 'contract.wasm', 'application/wasm');
+    expect(await detectContentError(file, '.wasm')).toBe(
+      'This file does not appear to be a valid WASM binary'
+    );
+  });
+
+  it('rejects an empty file', async () => {
+    const file = makeFile([], 'contract.wasm');
+    expect(await detectContentError(file, '.wasm')).toBe('File is empty');
+  });
+
+  it('rejects a truncated .wasm file with an incomplete magic header', async () => {
+    const file = makeFile([new Uint8Array([0x00, 0x61])], 'contract.wasm');
+    expect(await detectContentError(file, '.wasm')).toBe(
+      'This file does not appear to be a valid WASM binary'
+    );
+  });
+
+  it('accepts a valid .rs source file', async () => {
+    const file = makeFile(['pub fn main() {\n    // entry point\n}\n'], 'lib.rs', 'text/plain');
+    expect(await detectContentError(file, '.rs')).toBeNull();
+  });
+
+  it('accepts a .rs file that opens with a doc comment', async () => {
+    const file = makeFile(['//! crate docs\nuse std::io;\n'], 'lib.rs', 'text/plain');
+    expect(await detectContentError(file, '.rs')).toBeNull();
+  });
+
+  it('rejects a .rs file whose content is a binary blob', async () => {
+    const file = makeFile([new Uint8Array([0x00, 0x01, 0x02, 0x03, 0xff, 0xfe])], 'lib.rs');
+    expect(await detectContentError(file, '.rs')).toBe(
+      'This file does not appear to be valid Rust source'
+    );
+  });
+
+  it('does not magic-check types without a reliable signature (.toml)', async () => {
+    const file = makeFile(['[package]\nname = "x"\n'], 'Cargo.toml', 'text/plain');
+    expect(await detectContentError(file, '.toml')).toBeNull();
+  });
+});

--- a/frontend/components/FileUploadZone.tsx
+++ b/frontend/components/FileUploadZone.tsx
@@ -27,6 +27,7 @@ const STATUS_COLORS: Record<FileStatus, string> = {
   uploading: 'text-blue-600',
   complete: 'text-green-600',
   error: 'text-red-500',
+  cancelled: 'text-amber-600',
 };
 
 const STATUS_LABELS: Record<FileStatus, string> = {
@@ -35,6 +36,7 @@ const STATUS_LABELS: Record<FileStatus, string> = {
   uploading: 'Uploading…',
   complete: 'Ready',
   error: 'Failed',
+  cancelled: 'Cancelled',
 };
 
 const PROGRESS_COLORS: Record<FileStatus, 'blue' | 'green' | 'red' | 'gray'> = {
@@ -43,6 +45,7 @@ const PROGRESS_COLORS: Record<FileStatus, 'blue' | 'green' | 'red' | 'gray'> = {
   uploading: 'blue',
   complete: 'green',
   error: 'red',
+  cancelled: 'gray',
 };
 
 function fileExt(name: string): string {
@@ -60,16 +63,59 @@ function FileIcon({ name }: { name: string }) {
   return <span className="text-2xl leading-none select-none">{icon}</span>;
 }
 
+function formatSpeed(bps?: number): string {
+  if (!bps || bps <= 0) return '—';
+  const kbps = bps / 1024;
+  return kbps < 1024 ? `${kbps.toFixed(1)} KB/s` : `${(kbps / 1024).toFixed(1)} MB/s`;
+}
+
+function formatEta(seconds?: number): string {
+  if (seconds === undefined || !isFinite(seconds) || seconds <= 0) return '—';
+  if (seconds < 60) return `${Math.ceil(seconds)}s left`;
+  const m = Math.floor(seconds / 60);
+  const s = Math.ceil(seconds % 60);
+  return `${m}m ${s}s left`;
+}
+
+// Progress bar plus live transfer stats (percentage, speed, ETA) for one file.
+function FileUploadProgress({ entry }: { entry: UploadedFile }) {
+  const { file, status, progress, speedBps, etaSeconds } = entry;
+  return (
+    <div className="space-y-1" aria-label={`Upload progress for ${file.name}`}>
+      <ProgressBar
+        value={progress}
+        color={PROGRESS_COLORS[status]}
+        size="sm"
+        animated={status === 'uploading'}
+        showLabel={false}
+        className="mt-1"
+      />
+      <div className="flex items-center justify-between text-[11px] text-gray-400">
+        <span>{progress}%</span>
+        {status === 'uploading' && (
+          <span className="flex items-center gap-2">
+            <span>{formatSpeed(speedBps)}</span>
+            <span aria-hidden="true">·</span>
+            <span>{formatEta(etaSeconds)}</span>
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
 function FileRow({
   entry,
   onRemove,
   onRetry,
+  onCancel,
 }: {
   entry: UploadedFile;
   onRemove: (id: string) => void;
   onRetry: (id: string) => void;
+  onCancel: (id: string) => void;
 }) {
-  const { id, file, status, progress, error, preview } = entry;
+  const { id, file, status, error, preview } = entry;
 
   return (
     <li className="flex items-start gap-3 p-3 rounded-lg bg-gray-50 border border-gray-100 group">
@@ -91,7 +137,16 @@ function FileRow({
             <span className={`text-xs font-medium ${STATUS_COLORS[status]}`}>
               {STATUS_LABELS[status]}
             </span>
-            {status === 'error' && (
+            {status === 'uploading' && (
+              <button
+                onClick={() => onCancel(id)}
+                className="text-xs text-amber-600 hover:underline"
+                aria-label={`Cancel uploading ${file.name}`}
+              >
+                Cancel
+              </button>
+            )}
+            {(status === 'error' || status === 'cancelled') && (
               <button
                 onClick={() => onRetry(id)}
                 className="text-xs text-blue-600 hover:underline"
@@ -114,15 +169,8 @@ function FileRow({
 
         {error && <p className="text-xs text-red-500">{error}</p>}
 
-        {status !== 'pending' && status !== 'error' && (
-          <ProgressBar
-            value={progress}
-            color={PROGRESS_COLORS[status]}
-            size="sm"
-            animated={status === 'uploading'}
-            showLabel={false}
-            className="mt-1"
-          />
+        {(status === 'validating' || status === 'uploading' || status === 'complete') && (
+          <FileUploadProgress entry={entry} />
         )}
       </div>
     </li>
@@ -135,6 +183,7 @@ export default function FileUploadZone({
   maxSizeMB = 10,
   allowedTypes = ['.rs', '.wasm', '.toml', '.txt'],
   maxFiles = 5,
+  maxSizeByExt,
 }: FileUploadZoneProps) {
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -149,9 +198,10 @@ export default function FileUploadZone({
     onDrop,
     onInputChange,
     removeFile,
+    cancelUpload,
     retryFile,
     clearAll,
-  } = useFileUpload({ maxSizeMB, allowedTypes, maxFiles });
+  } = useFileUpload({ maxSizeMB, allowedTypes, maxFiles, maxSizeByExt });
 
   const readyFiles = files.filter(f => f.status === 'complete').map(f => f.file);
 
@@ -240,7 +290,13 @@ export default function FileUploadZone({
 
           <ul className="space-y-2" role="list" aria-label="Uploaded files">
             {files.map(entry => (
-              <FileRow key={entry.id} entry={entry} onRemove={removeFile} onRetry={retryFile} />
+              <FileRow
+                key={entry.id}
+                entry={entry}
+                onRemove={removeFile}
+                onRetry={retryFile}
+                onCancel={cancelUpload}
+              />
             ))}
           </ul>
 

--- a/frontend/hooks/useFileUpload.ts
+++ b/frontend/hooks/useFileUpload.ts
@@ -2,7 +2,13 @@
 
 import { useState, useCallback, useRef, DragEvent, ChangeEvent } from 'react';
 
-export type FileStatus = 'pending' | 'validating' | 'uploading' | 'complete' | 'error';
+export type FileStatus =
+  | 'pending'
+  | 'validating'
+  | 'uploading'
+  | 'complete'
+  | 'error'
+  | 'cancelled';
 
 export interface UploadedFile {
   id: string;
@@ -11,36 +17,166 @@ export interface UploadedFile {
   progress: number;
   error?: string;
   preview?: string;
+  /** Instantaneous upload speed in bytes/second (populated while uploading). */
+  speedBps?: number;
+  /** Estimated seconds remaining until the upload completes. */
+  etaSeconds?: number;
 }
 
 export interface FileValidationOptions {
   maxSizeMB?: number;
   allowedTypes?: string[];
   maxFiles?: number;
+  /**
+   * Per-extension size limits in MB. Takes precedence over `maxSizeMB` for a
+   * matching extension (e.g. compiled WASM binaries are allowed to be larger
+   * than the plain-text Rust sources they are built from).
+   */
+  maxSizeByExt?: Record<string, number>;
 }
 
 const DEFAULT_OPTIONS: Required<FileValidationOptions> = {
   maxSizeMB: 10,
   allowedTypes: ['.rs', '.wasm', '.toml', '.txt'],
   maxFiles: 5,
+  maxSizeByExt: { '.wasm': 10, '.rs': 5 },
 };
 
 function generateId(): string {
   return `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
 }
 
-function validateFile(file: File, options: Required<FileValidationOptions>): string | null {
-  const maxBytes = options.maxSizeMB * 1024 * 1024;
-  if (file.size > maxBytes) {
-    return `File exceeds ${options.maxSizeMB}MB limit`;
+/** Lower-cased extension including the leading dot, e.g. `".wasm"`. */
+export function getExt(name: string): string {
+  return '.' + (name.split('.').pop()?.toLowerCase() ?? '');
+}
+
+/** Magic bytes every WebAssembly binary starts with: `\0asm`. */
+export const WASM_MAGIC = [0x00, 0x61, 0x73, 0x6d];
+
+// Tokens a Rust source file's first non-empty line is expected to start with.
+const RUST_FIRST_LINE_TOKENS = [
+  'use',
+  'pub',
+  'mod',
+  'fn',
+  'impl',
+  'trait',
+  'struct',
+  'enum',
+  'const',
+  'static',
+  'type',
+  'let',
+  'unsafe',
+  'async',
+  'extern',
+  '//',
+  '//!',
+  '///',
+  '/*',
+  '#!',
+  '#[',
+];
+
+/**
+ * Read the first `n` bytes of a file. Prefers `Blob.arrayBuffer()` and falls
+ * back to `FileReader.readAsArrayBuffer()` on engines without it. Reads only a
+ * slice, so it stays cheap even for very large files.
+ */
+export async function readHeadBytes(file: File, n: number): Promise<Uint8Array> {
+  const blob = file.slice(0, n);
+  if (typeof blob.arrayBuffer === 'function') {
+    return new Uint8Array(await blob.arrayBuffer());
+  }
+  return new Promise<Uint8Array>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(new Uint8Array(reader.result as ArrayBuffer));
+    reader.onerror = () => reject(reader.error ?? new Error('Failed to read file'));
+    reader.readAsArrayBuffer(blob);
+  });
+}
+
+// Decode bytes as ASCII, mapping anything outside printable ASCII + common
+// whitespace to a replacement char. This is deliberately dependency-free (no
+// TextDecoder) and only used to inspect a source file's first line, whose Rust
+// keywords are always ASCII. Binary content collapses to replacement chars and
+// therefore never matches a Rust token.
+function bytesToAscii(bytes: Uint8Array): string {
+  let out = '';
+  for (let i = 0; i < bytes.length; i++) {
+    const c = bytes[i];
+    const printable = c === 9 || c === 10 || c === 13 || (c >= 32 && c <= 126);
+    out += printable ? String.fromCharCode(c) : '�';
+  }
+  return out;
+}
+
+function firstNonEmptyLine(text: string): string {
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (line) return line;
+  }
+  return '';
+}
+
+function lineLooksLikeRust(line: string): boolean {
+  return RUST_FIRST_LINE_TOKENS.some(tok => {
+    if (!line.startsWith(tok)) return false;
+    // Require a word boundary for keyword tokens so `fn` does not match `fnord`;
+    // symbol tokens (`//`, `#[`, …) match as-is.
+    if (!/^[a-z]/.test(tok)) return true;
+    const next = line.charAt(tok.length);
+    return next === '' || !/[A-Za-z0-9_]/.test(next);
+  });
+}
+
+/**
+ * Content-based validation using magic bytes / first-line heuristics, so a file
+ * renamed to bypass the extension check (e.g. `malware.exe` → `contract.wasm`)
+ * is rejected client-side before any upload begins. Returns an error message,
+ * or `null` when the content is consistent with the claimed type.
+ */
+export async function detectContentError(file: File, ext: string): Promise<string | null> {
+  if (file.size === 0) {
+    return 'File is empty';
   }
 
-  const ext = '.' + file.name.split('.').pop()?.toLowerCase();
+  if (ext === '.wasm') {
+    const head = await readHeadBytes(file, WASM_MAGIC.length);
+    const valid =
+      head.length >= WASM_MAGIC.length && WASM_MAGIC.every((byte, i) => head[i] === byte);
+    return valid ? null : 'This file does not appear to be a valid WASM binary';
+  }
+
+  if (ext === '.rs') {
+    const head = await readHeadBytes(file, 512);
+    const firstLine = firstNonEmptyLine(bytesToAscii(head));
+    return lineLooksLikeRust(firstLine)
+      ? null
+      : 'This file does not appear to be valid Rust source';
+  }
+
+  // .toml/.txt (and any other allowed type) have no reliable magic signature.
+  return null;
+}
+
+function resolveMaxSizeMB(file: File, options: Required<FileValidationOptions>): number {
+  return options.maxSizeByExt[getExt(file.name)] ?? options.maxSizeMB;
+}
+
+function validateFile(file: File, options: Required<FileValidationOptions>): string | null {
+  const ext = getExt(file.name);
   const mime = file.type;
 
   const isAllowedExt = options.allowedTypes.some(t => (t.startsWith('.') ? t === ext : t === mime));
   if (!isAllowedExt) {
     return `File type "${ext}" is not allowed. Accepted: ${options.allowedTypes.join(', ')}`;
+  }
+
+  const maxMB = resolveMaxSizeMB(file, options);
+  if (file.size > maxMB * 1024 * 1024) {
+    return `File exceeds the ${maxMB}MB size limit`;
   }
 
   return null;
@@ -57,7 +193,11 @@ async function generatePreview(file: File): Promise<string | undefined> {
 }
 
 export function useFileUpload(options: FileValidationOptions = {}) {
-  const opts = { ...DEFAULT_OPTIONS, ...options };
+  const opts: Required<FileValidationOptions> = {
+    ...DEFAULT_OPTIONS,
+    ...options,
+    maxSizeByExt: options.maxSizeByExt ?? DEFAULT_OPTIONS.maxSizeByExt,
+  };
   const [files, setFiles] = useState<UploadedFile[]>([]);
   const [isDragActive, setIsDragActive] = useState(false);
   const abortRefs = useRef<Record<string, AbortController>>({});
@@ -69,16 +209,21 @@ export function useFileUpload(options: FileValidationOptions = {}) {
   }, []);
 
   const simulateUpload = useCallback(
-    async (id: string, controller: AbortController) => {
+    async (id: string, controller: AbortController, fileSize: number) => {
+      const startedAt = Date.now();
       const intervals = [15, 30, 45, 60, 75, 88, 95, 100];
       for (const pct of intervals) {
         if (controller.signal.aborted) return;
         await new Promise(r => setTimeout(r, 250 + Math.random() * 200));
         if (controller.signal.aborted) return;
-        updateFile(id, { progress: pct });
+        const elapsedSec = Math.max((Date.now() - startedAt) / 1000, 0.001);
+        const bytesSoFar = (fileSize * pct) / 100;
+        const speedBps = bytesSoFar / elapsedSec;
+        const etaSeconds = speedBps > 0 ? (fileSize - bytesSoFar) / speedBps : 0;
+        updateFile(id, { progress: pct, speedBps, etaSeconds });
       }
       if (!controller.signal.aborted) {
-        updateFile(id, { status: 'complete', progress: 100 });
+        updateFile(id, { status: 'complete', progress: 100, speedBps: undefined, etaSeconds: 0 });
       }
     },
     [updateFile]
@@ -116,10 +261,16 @@ export function useFileUpload(options: FileValidationOptions = {}) {
           continue;
         }
 
+        const contentError = await detectContentError(entry.file, getExt(entry.file.name));
+        if (contentError) {
+          updateFile(entry.id, { status: 'error', error: contentError });
+          continue;
+        }
+
         const controller = new AbortController();
         abortRefs.current[entry.id] = controller;
         updateFile(entry.id, { status: 'uploading', progress: 0 });
-        simulateUpload(entry.id, controller);
+        simulateUpload(entry.id, controller, entry.file.size);
       }
     },
     [files.length, opts, updateFile, simulateUpload]
@@ -174,24 +325,49 @@ export function useFileUpload(options: FileValidationOptions = {}) {
     });
   }, []);
 
-  const retryFile = useCallback(
+  const cancelUpload = useCallback(
     (id: string) => {
-      setFiles((prev: UploadedFile[]) => {
-        const target = prev.find((f: UploadedFile) => f.id === id);
-        if (!target) return prev;
-        const error = validateFile(target.file, opts);
-        if (error) return prev;
-        return prev.map((f: UploadedFile) =>
-          f.id === id
-            ? { ...f, status: 'uploading' as FileStatus, progress: 0, error: undefined }
-            : f
-        );
+      abortRefs.current[id]?.abort();
+      delete abortRefs.current[id];
+      updateFile(id, {
+        status: 'cancelled',
+        error: 'Upload cancelled',
+        speedBps: undefined,
+        etaSeconds: undefined,
+      });
+    },
+    [updateFile]
+  );
+
+  const retryFile = useCallback(
+    async (id: string) => {
+      const target = files.find((f: UploadedFile) => f.id === id);
+      if (!target) return;
+
+      const error = validateFile(target.file, opts);
+      if (error) {
+        updateFile(id, { status: 'error', error });
+        return;
+      }
+
+      const contentError = await detectContentError(target.file, getExt(target.file.name));
+      if (contentError) {
+        updateFile(id, { status: 'error', error: contentError });
+        return;
+      }
+
+      updateFile(id, {
+        status: 'uploading',
+        progress: 0,
+        error: undefined,
+        speedBps: undefined,
+        etaSeconds: undefined,
       });
       const controller = new AbortController();
       abortRefs.current[id] = controller;
-      simulateUpload(id, controller);
+      simulateUpload(id, controller, target.file.size);
     },
-    [opts, simulateUpload]
+    [files, opts, updateFile, simulateUpload]
   );
 
   const clearAll = useCallback(() => {
@@ -221,6 +397,7 @@ export function useFileUpload(options: FileValidationOptions = {}) {
     onDrop,
     onInputChange,
     removeFile,
+    cancelUpload,
     retryFile,
     clearAll,
   };

--- a/tests/e2e/file-upload-magic-bytes.spec.js
+++ b/tests/e2e/file-upload-magic-bytes.spec.js
@@ -1,0 +1,70 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+// A file that claims to be a WASM binary (`contract.wasm`, `application/wasm`)
+// but whose bytes are actually a DOS/PE executable — it starts with `MZ`
+// (0x4D 0x5A). This is the classic "rename malware.exe to contract.wasm"
+// bypass that the extension/MIME check alone cannot catch and that the
+// hardened `useFileUpload` hook must now reject client-side, before any bytes
+// leave the browser (the backend `upload_sanitization/magic.rs` guard is the
+// server-side counterpart).
+const SPOOFED_WASM = Buffer.from([0x4d, 0x5a, 0x90, 0x00, 0x03, 0x00, 0x00, 0x00]);
+
+// `\0asm` + version 1 — the minimal valid WebAssembly module header.
+const GENUINE_WASM = Buffer.from([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]);
+
+const WASM_ERROR = 'This file does not appear to be a valid WASM binary';
+
+// Requests that would represent the file actually being uploaded/scanned. A
+// correct client-side guard rejects the spoofed file before any of these fire.
+function isUploadRequest(req) {
+  return req.method() !== 'GET' && /upload|scan|analyze|contract/i.test(req.url());
+}
+
+test.describe('FileUploadZone – client-side magic byte validation (#432)', () => {
+  test('rejects an .exe renamed to .wasm without issuing an upload request', async ({ page }) => {
+    // Capture every request the page makes so we can prove the rejected file
+    // never triggers a network upload.
+    /** @type {import('@playwright/test').Request[]} */
+    const requests = [];
+    page.on('request', req => requests.push(req));
+
+    await page.goto('/');
+
+    // The scanner opens on the "Paste Code" tab; switch to file upload.
+    await page.getByRole('button', { name: /Upload Files/i }).click();
+
+    const uploadRequestsBefore = requests.filter(isUploadRequest).length;
+
+    // Feed the spoofed binary to the (visually hidden) file input.
+    await page.locator('input[type="file"]').setInputFiles({
+      name: 'contract.wasm',
+      mimeType: 'application/wasm',
+      buffer: SPOOFED_WASM,
+    });
+
+    // The specific, content-derived error message must be shown to the user...
+    await expect(page.getByText(WASM_ERROR)).toBeVisible();
+    // ...the row must be marked Failed, never Ready...
+    await expect(page.getByText('Failed')).toBeVisible();
+    await expect(page.getByText('Ready', { exact: true })).toHaveCount(0);
+
+    // ...and no upload/scan request may have been issued for the rejected file.
+    const uploadRequestsAfter = requests.filter(isUploadRequest).length;
+    expect(uploadRequestsAfter).toBe(uploadRequestsBefore);
+  });
+
+  test('accepts a correctly-signed .wasm binary (control)', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('button', { name: /Upload Files/i }).click();
+
+    await page.locator('input[type="file"]').setInputFiles({
+      name: 'contract.wasm',
+      mimeType: 'application/wasm',
+      buffer: GENUINE_WASM,
+    });
+
+    // A genuine WASM header must not trigger the magic-byte rejection.
+    await expect(page.getByText(WASM_ERROR)).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary

Hardens the file-upload flow so that files are validated by **content**, not just by their (client-controlled, trivially spoofable) extension and `File.type`. A user can rename `malware.exe` to `contract.wasm`; previously the frontend accepted it and only the backend `upload_sanitization/magic.rs` rejected it, wasting bandwidth. This adds client-side magic-byte detection, per-type size limits, live progress with speed/ETA, and upload cancellation.

Closes #432.

## Changes

- **`frontend/hooks/useFileUpload.ts`**
  - `detectContentError()` reads only the file's leading bytes (via `Blob.arrayBuffer()`, with a `FileReader.readAsArrayBuffer()` fallback) and validates them:
    - `.wasm` → must start with the WASM magic `\0asm` (`00 61 73 6d`).
    - `.rs` → first non-empty line must look like Rust (`use`, `pub`, `mod`, `fn`, `impl`, `trait`, `struct`, `enum`, doc/line/block comments, attributes, …). Binary content collapses to replacement chars and is rejected.
    - Empty files are rejected up front.
  - Per-extension size limits via a `maxSizeByExt` option, **defaulting to 10 MB for `.wasm` and 5 MB for `.rs`** (see note below), enforced before any upload begins with the message `File exceeds the <N>MB size limit`.
  - `cancelUpload()` aborts the in-flight (simulated) upload via `AbortController.abort()`, moving the row to a new `cancelled` state; `retryFile()` re-runs both validation passes.
  - Upload progress now reports instantaneous **speed** and **ETA**.
- **`frontend/components/FileUploadZone.tsx`**
  - New `FileUploadProgress` sub-component: percentage bar + upload speed (KB/s, MB/s) + estimated time remaining.
  - Per-row **Cancel** button while uploading and **Retry** on failure/cancellation; new `Cancelled` status styling.
  - Forwards a `maxSizeByExt` prop through to the hook.
- **`frontend/__tests__/useFileUpload.magic.test.ts`** — 10 unit tests for the magic-byte logic.
- **`tests/e2e/file-upload-magic-bytes.spec.js`** — Playwright e2e: uploading an `.exe` renamed to `.wasm` shows the client-side error and issues **no** upload request; a genuine WASM header is accepted (control).

## Acceptance criteria

- [x] Client-side magic-byte detection (WASM header + Rust first-line heuristic)
- [x] Per-type size limits (10 MB `.wasm` / 5 MB `.rs`) with inline pre-upload rejection
- [x] `FileUploadProgress` (name, %, speed, ETA)
- [x] Upload cancellation via `AbortController.abort()`
- [x] Specific errors: `This file does not appear to be a valid WASM binary` vs `File exceeds the <N>MB size limit`
- [x] Unit tests: valid `.wasm`, `.wasm` renamed from `.exe`, empty file, truncated file, valid `.rs`
- [x] Playwright e2e: non-WASM upload shows client-side error with no network request

**Note on the size-limit prop:** the criterion asks for a `maxFileSize` prop defaulting to "10 MB for `.wasm`, 5 MB for `.rs`". Since that default is inherently per-extension, this is implemented as `maxSizeByExt?: Record<string, number>` (default `{ '.wasm': 10, '.rs': 5 }`), which composes with the component's existing `maxSizeMB` fallback. Happy to rename if you'd prefer the literal `maxFileSize`.

## Testing

Run in `frontend/` (after `npm ci` there and `npm ci && npm run build` in `component-library/`, mirroring the CI `frontend` job):

- `npm run lint` — clean (no new warnings)
- `npm test` — **83/83 passing**, including the 10 new magic-byte tests
- `npm run build` — succeeds
- Prettier `format:check` — clean for the changed `frontend/**` files

The Playwright spec follows the repo convention in `tests/e2e/`; there is no e2e job in CI, so it is not run by the PR pipeline.

## Notes

- The content sniff reads only a small slice of the file, so it stays cheap for large binaries.
- `TextDecoder` is deliberately avoided (jsdom test-env gap); a small ASCII decoder is used solely to inspect a Rust file's first line, whose keywords are always ASCII.
