### PR TITLE
fix(auth): enforce password strength policy and implement needs_rehash

### DIFF
--- a/examples/auth_server.rs
+++ b/examples/auth_server.rs
@@ -382,8 +382,28 @@ async fn register(
     }
     drop(users);
 
-    // Hash password
+    // Enforce password strength policy before hashing.  Weak passwords are
+    // rejected at registration time to prevent weak credentials from ever
+    // reaching the database.
     let password_service = PasswordService::new(PasswordConfig::high_security());
+    match password_service.check_password_strength(password) {
+        Ok(soroban_security_scanner::auth::PasswordStrength::Weak) => {
+            return Ok(Json(json!({
+                "success": false,
+                "error": "Password is too weak. Use at least 8 characters with a \
+                           mix of uppercase, lowercase, numbers, and special characters."
+            })));
+        }
+        Err(e) => {
+            return Ok(Json(json!({
+                "success": false,
+                "error": format!("Invalid password: {}", e)
+            })));
+        }
+        _ => {} // Medium / Strong / VeryStrong – proceed.
+    }
+
+    // Hash password (strength is re-validated internally by hash_password).
     let password_hash = password_service
         .hash_password(password)
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;

--- a/src/auth/password.rs
+++ b/src/auth/password.rs
@@ -85,6 +85,22 @@ impl PasswordService {
             ));
         }
 
+        // Enforce minimum password strength before hashing.
+        // Weak passwords (score 0-2) are rejected to prevent credential
+        // stuffing and brute-force attacks on stored hashes.
+        match self.check_password_strength(password)? {
+            PasswordStrength::Weak => {
+                return Err(PasswordError::WeakPassword(
+                    "Password does not meet the minimum strength requirements. \
+                     Use at least 8 characters and include uppercase letters, \
+                     lowercase letters, numbers, and special characters."
+                        .to_string(),
+                ));
+            }
+            // Medium, Strong, and VeryStrong are accepted.
+            _ => {}
+        }
+
         let salt = SaltString::generate(&mut OsRng);
 
         let params = Params::new(
@@ -268,17 +284,43 @@ impl PasswordService {
 
     pub fn needs_rehash(&self, hash: &str) -> bool {
         let parsed_hash = match PasswordHash::new(hash) {
-            Ok(hash) => hash,
-            Err(_) => return true, // Invalid format, needs rehash
+            Ok(h) => h,
+            Err(_) => return true, // Malformed PHC string – must rehash.
         };
 
-        // Check if the hash uses the current algorithm and parameters
+        // Reject any algorithm other than Argon2id.
         match argon2::Algorithm::try_from(parsed_hash.algorithm) {
-            Ok(argon2::Algorithm::Argon2id) => {
-                // This is a simplified check - in production, you'd want more detailed comparison
-                parsed_hash.params.is_empty() // No params found => needs rehash
+            Ok(argon2::Algorithm::Argon2id) => {}
+            _ => return true,
+        }
+
+        // Check the version tag embedded in the PHC string.
+        // V0x13 = version 19 (0x13).  If the stored hash was produced with an
+        // older version it must be re-hashed.
+        if let Some(stored_version) = parsed_hash.version {
+            let current_version: u32 = match self.config.version {
+                argon2::Version::V0x10 => 16,
+                argon2::Version::V0x13 => 19,
+            };
+            if stored_version != current_version {
+                return true;
             }
-            _ => true, // Different algorithm, needs rehash
+        }
+
+        // Extract the stored Argon2 cost parameters from the PHC string and
+        // compare them against the service's current configuration.  Any
+        // mismatch means the hash was produced under weaker (or simply
+        // different) settings and should be upgraded on the next successful
+        // login.
+        match Params::try_from(&parsed_hash) {
+            Ok(stored_params) => {
+                stored_params.m_cost() != self.config.memory_cost
+                    || stored_params.t_cost() != self.config.time_cost
+                    || stored_params.p_cost() != self.config.parallelism
+                    || stored_params.output_len() != Some(self.config.hash_length)
+            }
+            // Could not decode params from the stored hash – safest to rehash.
+            Err(_) => true,
         }
     }
 }
@@ -420,5 +462,116 @@ mod tests {
         assert!(service.hash_password("").is_err());
         assert!(service.verify_password("", "some_hash").is_err());
         assert!(service.check_password_strength("").is_err());
+    }
+
+    // -------------------------------------------------------------------------
+    // Password strength enforcement at hash time
+    // -------------------------------------------------------------------------
+
+    /// Weak passwords must be rejected by hash_password(), not silently stored.
+    #[test]
+    fn test_hash_password_rejects_weak_passwords() {
+        let service = PasswordService::default();
+
+        // Single character – definitely Weak.
+        let result = service.hash_password("a");
+        assert!(
+            result.is_err(),
+            "hash_password() must reject a single-character password"
+        );
+        assert!(matches!(
+            result.unwrap_err(),
+            PasswordError::WeakPassword(_)
+        ));
+
+        // Short numeric-only – Weak.
+        let result = service.hash_password("123");
+        assert!(
+            result.is_err(),
+            "hash_password() must reject a numeric-only short password"
+        );
+        assert!(matches!(
+            result.unwrap_err(),
+            PasswordError::WeakPassword(_)
+        ));
+    }
+
+    /// Medium (and above) passwords must be accepted by hash_password().
+    #[test]
+    fn test_hash_password_accepts_medium_and_stronger_passwords() {
+        let service = PasswordService::default();
+
+        // Medium – should succeed.
+        assert!(
+            service.hash_password("Passw0rdX9").is_ok(),
+            "hash_password() must accept a Medium-strength password"
+        );
+
+        // Strong – should succeed.
+        assert!(
+            service.hash_password("Str0ngP@ssw0rd!").is_ok(),
+            "hash_password() must accept a Strong password"
+        );
+
+        // Very strong – should succeed.
+        assert!(
+            service.hash_password("V3ry$tr0ng&P@ssw0rd!2024#").is_ok(),
+            "hash_password() must accept a VeryStrong password"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // needs_rehash() – real parameter comparison
+    // -------------------------------------------------------------------------
+
+    /// A hash produced with the default config should not need rehashing when
+    /// checked against the same config.
+    #[test]
+    fn test_needs_rehash_same_config_returns_false() {
+        let service = PasswordService::new(PasswordConfig::default());
+        let hash = service.hash_password("Str0ngP@ssw0rd!").unwrap();
+
+        assert!(
+            !service.needs_rehash(&hash),
+            "needs_rehash() must return false when params match the current config"
+        );
+    }
+
+    /// A hash produced with the default config should need rehashing when
+    /// evaluated against a service configured with higher security parameters.
+    #[test]
+    fn test_needs_rehash_different_config_returns_true() {
+        let default_service = PasswordService::new(PasswordConfig::default());
+        let hash = default_service.hash_password("Str0ngP@ssw0rd!").unwrap();
+
+        // high_security uses different m_cost, t_cost, p_cost, and output_len.
+        let high_security_service = PasswordService::new(PasswordConfig::high_security());
+        assert!(
+            high_security_service.needs_rehash(&hash),
+            "needs_rehash() must return true when stored params differ from current config"
+        );
+    }
+
+    /// A hash produced with high_security config should not need rehashing when
+    /// checked against the same high_security config.
+    #[test]
+    fn test_needs_rehash_high_security_same_config_returns_false() {
+        let service = PasswordService::new(PasswordConfig::high_security());
+        let hash = service.hash_password("V3ry$tr0ng&P@ssw0rd!2024#").unwrap();
+
+        assert!(
+            !service.needs_rehash(&hash),
+            "needs_rehash() must return false for a hash that matches the high-security config"
+        );
+    }
+
+    /// An entirely invalid hash string must trigger a rehash.
+    #[test]
+    fn test_needs_rehash_invalid_hash_returns_true() {
+        let service = PasswordService::default();
+        assert!(
+            service.needs_rehash("not-a-valid-phc-hash"),
+            "needs_rehash() must return true for a malformed hash"
+        );
     }
 }

--- a/tests/auth_integration_tests.rs
+++ b/tests/auth_integration_tests.rs
@@ -610,22 +610,32 @@ async fn test_multiple_user_sessions() {
 #[test]
 fn test_password_rehash_detection() {
     let password_service = PasswordService::new(PasswordConfig::default());
-    let password = "test-password-123!";
+    let password = "Str0ngP@ssw0rd!";
 
-    // Hash password with default config
+    // Hash password with default config.
     let hash = password_service.hash_password(password).unwrap();
 
-    // Check if rehash is needed (should be false for same config)
-    let needs_rehash = password_service.needs_rehash(&hash);
-    assert!(!needs_rehash);
+    // Same config — parameters match, so no rehash is required.
+    assert!(
+        !password_service.needs_rehash(&hash),
+        "needs_rehash() must return false when the stored hash parameters \
+         match the current configuration"
+    );
 
-    // Create a service with different config
+    // A service configured with higher security parameters should flag the
+    // existing hash for upgrade because m_cost / t_cost / p_cost differ.
     let high_security_service = PasswordService::new(PasswordConfig::high_security());
+    assert!(
+        high_security_service.needs_rehash(&hash),
+        "needs_rehash() must return true when stored params are weaker than \
+         the current high-security configuration"
+    );
 
-    // Check if rehash is needed with different config
-    let needs_rehash = high_security_service.needs_rehash(&hash);
-    // This might be true or false depending on the actual parameters
-    // The important thing is that the function works
+    // A malformed hash must always trigger a rehash.
+    assert!(
+        password_service.needs_rehash("invalid-hash"),
+        "needs_rehash() must return true for a malformed hash string"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Security fix for three related vulnerabilities in the password service:

1. Weak password acceptance (CWE-521) hash_password() previously accepted any non-empty string, allowing trivially weak credentials such as "a" or "123" to reach the database. hash_password() now delegates to check_password_strength() before hashing and returns PasswordError::WeakPassword for any password that scores as Weak (score 0-2). Medium, Strong, and VeryStrong passwords are accepted unchanged.

2. needs_rehash() stub always returned false (CWE-916) The original implementation checked parsed_hash.params.is_empty(), which is never true for a well-formed Argon2id PHC string. Hashes produced under weaker cost parameters were therefore never upgraded on subsequent logins. The function now uses Params::try_from(&hash) to extract the stored m_cost, t_cost, p_cost, and output_len values and compares them against the service's current PasswordConfig. Any mismatch (including algorithm or version differences) returns true so callers can trigger a transparent rehash on the next successful login.

3. Registration path bypassed strength check (CWE-521) The /auth/register handler in examples/auth_server.rs called hash_password() directly without a prior strength check. The handler now calls check_password_strength() explicitly before hashing and returns a descriptive 200-error payload for Weak passwords, giving the client actionable feedback.

Tests added / updated:
- test_hash_password_rejects_weak_passwords
- test_hash_password_accepts_medium_and_stronger_passwords
- test_needs_rehash_same_config_returns_false
- test_needs_rehash_different_config_returns_true
- test_needs_rehash_high_security_same_config_returns_false
- test_needs_rehash_invalid_hash_returns_true
- test_password_rehash_detection (integration test strengthened with concrete assertions replacing the previous no-op comments)

All 388 lib tests pass. cargo fmt --check and cargo check --lib clean.

closes #492 